### PR TITLE
adds single account public client app support

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -119,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   msal_auth:
     dependency: "direct main"
     description:
@@ -259,10 +259,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   win32:
     dependency: transitive
     description:
@@ -297,4 +297,4 @@ packages:
     version: "1.0.4"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.13.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -119,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.11.0"
   msal_auth:
     dependency: "direct main"
     description:
@@ -259,10 +259,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -275,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "13.0.0"
   win32:
     dependency: transitive
     description:
@@ -297,4 +297,4 @@ packages:
     version: "1.0.4"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.13.0"

--- a/lib/msal_auth.dart
+++ b/lib/msal_auth.dart
@@ -9,12 +9,18 @@ import 'msal_auth.dart';
 export 'core/extensions.dart';
 export 'models/models.dart';
 
+const _methodChannel = MethodChannel('msal_auth');
+
+enum PublicClientAccountAppType {
+  singleAccount,
+  multipleAccount,
+}
+
 class MsalAuth {
-  final List<String> _scopes;
-
-  MsalAuth._create({required List<String> scopes}) : _scopes = scopes;
-
-  static const _methodChannel = MethodChannel('msal_auth');
+  final MsalAuthImpl? _msalAuthImpl;
+  MsalAuth._create({
+    required MsalAuthImpl msalAuthImpl,
+  }) : _msalAuthImpl = msalAuthImpl;
 
   /// Initializes MSAL with required data.
   static Future<MsalAuth> createPublicClientApplication({
@@ -23,10 +29,11 @@ class MsalAuth {
     String? loginHint,
     AndroidConfig? androidConfig,
     IosConfig? iosConfig,
+    PublicClientAccountAppType publicClientAppAccountType =
+        PublicClientAccountAppType.multipleAccount,
   }) async {
     try {
       late final Map<String, dynamic> arguments;
-
       if (Platform.isAndroid) {
         assert(androidConfig != null, 'Android config can not be null');
         final config =
@@ -42,7 +49,10 @@ class MsalAuth {
         final file = File('${directory.path}/msal_auth_config.json');
         await file.writeAsBytes(utf8.encode(json.encode(map)));
 
-        arguments = {'configFilePath': file.path};
+        arguments = {
+          'configFilePath': file.path,
+          'publicClientAppAccountType': publicClientAppAccountType.name,
+        };
       } else if (Platform.isIOS) {
         assert(iosConfig != null, 'iOS config can not be null');
         arguments = <String, dynamic>{
@@ -55,14 +65,73 @@ class MsalAuth {
       }
 
       await _methodChannel.invokeMethod('initialize', arguments);
-      return MsalAuth._create(scopes: scopes);
+      return MsalAuth._create(
+          msalAuthImpl: switch (publicClientAppAccountType) {
+        PublicClientAccountAppType.multipleAccount =>
+          MsalMultipleAccountImpl(scopes: scopes),
+        PublicClientAccountAppType.singleAccount =>
+          MsalSingleAccountImpl(scopes: scopes),
+      });
     } on PlatformException catch (e) {
       throw e.msalException;
     }
   }
 
+  Future<MsalUser?> login() {
+    assert(
+      _msalAuthImpl != null,
+      'Must create public client application before attempting to login',
+    );
+    return _msalAuthImpl!.login();
+  }
+
+  Future<MsalUser?> acquireToken() {
+    assert(
+      _msalAuthImpl != null,
+      'Must create public client application before attempting to acquire token',
+    );
+    return _msalAuthImpl!.acquireToken();
+  }
+
+  Future<MsalUser?> acquireTokenSilent() {
+    assert(
+      _msalAuthImpl != null,
+      'Must create public client application before attempting to acquire token silently',
+    );
+    return _msalAuthImpl!.acquireTokenSilent();
+  }
+
+  Future<void> logout() {
+    assert(
+      _msalAuthImpl != null,
+      'Must create public client application before attempting to logout',
+    );
+    return _msalAuthImpl!.logout();
+  }
+}
+
+mixin MsalAuthImpl {
+  Future<MsalUser?> login();
+  Future<MsalUser?> acquireToken();
+  Future<MsalUser?> acquireTokenSilent();
+  Future<void> logout();
+}
+
+class MsalMultipleAccountImpl implements MsalAuthImpl {
+  final List<String> _scopes;
+
+  MsalMultipleAccountImpl({required List<String> scopes}) : _scopes = scopes;
+
+  @override
+  Future<MsalUser?> login() {
+    throw UnimplementedError(
+      'Login not available for multiple account public client application',
+    );
+  }
+
   /// Acquire a token interactively for the given [scopes]
   /// return [UserAdModel] contains user information but token and expiration date
+  @override
   Future<MsalUser?> acquireToken() async {
     try {
       assert(_scopes.isNotEmpty, 'Scopes can not be empty');
@@ -79,6 +148,7 @@ class MsalAuth {
 
   /// Acquire a token silently, with no user interaction, for the given [scopes]
   /// return [UserAdModel] contains user information but token and expiration date
+  @override
   Future<MsalUser?> acquireTokenSilent() async {
     assert(_scopes.isNotEmpty, 'Scopes can not be empty');
     final arguments = <String, dynamic>{'scopes': _scopes};
@@ -98,10 +168,95 @@ class MsalAuth {
   }
 
   /// Logout user from Microsoft account.
+  @override
   Future<void> logout() async {
     try {
       if (Platform.isAndroid) {
         await _methodChannel.invokeMethod('loadAccounts');
+      }
+      await _methodChannel.invokeMethod('logout', <String, dynamic>{});
+    } on PlatformException catch (e) {
+      throw e.msalException;
+    }
+  }
+}
+
+class MsalSingleAccountImpl implements MsalAuthImpl {
+  static const _methodChannel = MethodChannel('msal_auth');
+  final List<String> _scopes;
+
+  MsalSingleAccountImpl({required List<String> scopes}) : _scopes = scopes;
+
+  /// Login with the given [scopes]
+  /// return [UserAdModel] containing user information
+  @override
+  Future<MsalUser?> login() async {
+    try {
+      assert(_scopes.isNotEmpty, 'Scopes cannot be empty');
+      final arguments = <String, dynamic>{'scopes': _scopes};
+      late String? json;
+      if (Platform.isAndroid) {
+        await _methodChannel.invokeMethod('loadAccount');
+        json = await _methodChannel.invokeMethod('login', arguments);
+      } else {
+        json = await _methodChannel.invokeMethod('acquireToken', arguments);
+      }
+      if (json != null) {
+        return MsalUser.fromJson(jsonDecode(json));
+      }
+      return null;
+    } on PlatformException catch (e) {
+      throw e.msalException;
+    }
+  }
+
+  /// Acquire a token interactively for the given [scopes]
+  /// return [UserAdModel] containing user information
+  @override
+  Future<MsalUser?> acquireToken() async {
+    try {
+      assert(_scopes.isNotEmpty, 'Scopes cannot be empty');
+      if (Platform.isAndroid) {
+        await _methodChannel.invokeMethod('loadAccount');
+      }
+      final arguments = <String, dynamic>{'scopes': _scopes};
+      final json = await _methodChannel.invokeMethod('acquireToken', arguments);
+      if (json != null) {
+        return MsalUser.fromJson(jsonDecode(json));
+      }
+      return null;
+    } on PlatformException catch (e) {
+      throw e.msalException;
+    }
+  }
+
+  /// Acquire a token silently, with no user interaction, for the given [scopes]
+  /// return [UserAdModel] containing user information
+  @override
+  Future<MsalUser?> acquireTokenSilent() async {
+    assert(_scopes.isNotEmpty, 'Scopes cannot be empty');
+    if (Platform.isAndroid) {
+      await _methodChannel.invokeMethod('loadAccount');
+    }
+    final arguments = <String, dynamic>{'scopes': _scopes};
+    try {
+      final json =
+          await _methodChannel.invokeMethod('acquireTokenSilent', arguments);
+      if (json != null) {
+        return MsalUser.fromJson(jsonDecode(json));
+      }
+      return null;
+    } on PlatformException catch (e) {
+      throw e.msalException;
+    }
+  }
+
+  /// Logout user from Microsoft account.
+  @override
+  Future<void> logout() async {
+    try {
+      if (Platform.isAndroid) {
+        await _methodChannel.invokeMethod('loadAccount');
       }
       await _methodChannel.invokeMethod('logout', <String, dynamic>{});
     } on PlatformException catch (e) {


### PR DESCRIPTION
This PR is for adding single account public client app support. Addresses issue #21

Android changes:
Introduced the MsalAuth interface to define common methods for both single and multiple account implementations.

Created MsalAuthSingleAccount and MsalAuthMultipleAccount classes, which implement MsalAuth, encapsulating their account management logic.

The initialize method in MsalAuthImpl now checks for the account type and instantiates the appropriate implementation based on accountMode (MsalAuthSingleAccount or MsalAuthMultipleAccount) .

Introduced wrapper methods in MsalAuthImpl that do initial initialisation checks before delegating the logic to the MsalAuth implementation.

Moved method to handle loading accounts from Msal to MsalAuthMultipleAccount, and created a method and loading a specific account in MsalAuthSingleAccount.


Flutter changes:
Introduced the MsalAuthImpl mixin to define common methods for both single and multiple account implementations.

Created MsalMultipleAccountImpl and MsalSingleAccountImpl classes, which implement MsalAuth, encapsulating their account management logic.

Added a new parameter “publicClientAppAccountType” to createPublicClientApplication

The initialize method in MsalAuth now checks for the account type and instantiates the appropriate implementation  (MsalMultipleAccountImpl or MsalSingleAccountImpl) .

Introduced wrapper methods in MsalAuth that do initial initialisation checks before delegating the logic to the MsalAuthImpl implementation.