### PR TITLE
test: Add tests for single account PCA

### DIFF
--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../models/models.dart';
@@ -16,26 +16,28 @@ final class Utils {
     IosConfig? iosConfig,
   }) async {
     final arguments = <String, dynamic>{};
-    if (Platform.isAndroid) {
-      assert(androidConfig != null, 'Android config can not be null');
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        assert(androidConfig != null, 'Android config can not be null');
 
-      final configStr =
-          await rootBundle.loadString(androidConfig!.configFilePath);
-      final config = json.decode(configStr) as Map<String, dynamic>
-        ..addAll({
-          'client_id': clientId,
-          'redirect_uri': androidConfig.redirectUri,
+        final configStr =
+            await rootBundle.loadString(androidConfig!.configFilePath);
+        final config = json.decode(configStr) as Map<String, dynamic>
+          ..addAll({
+            'client_id': clientId,
+            'redirect_uri': androidConfig.redirectUri,
+          });
+
+        arguments.addAll({'config': config});
+      case TargetPlatform.iOS:
+        assert(iosConfig != null, 'iOS config can not be null');
+        arguments.addAll({
+          'clientId': clientId,
+          'authority': iosConfig!.authority,
+          'broker': iosConfig.broker.name,
+          'authorityType': iosConfig.authorityType.name,
         });
-
-      arguments.addAll({'config': config});
-    } else if (Platform.isIOS) {
-      assert(iosConfig != null, 'iOS config can not be null');
-      arguments.addAll({
-        'clientId': clientId,
-        'authority': iosConfig!.authority,
-        'broker': iosConfig.broker.name,
-        'authorityType': iosConfig.authorityType.name,
-      });
+      default:
     }
     return arguments;
   }

--- a/test/data/test_data.dart
+++ b/test/data/test_data.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+final androidConfigString = jsonEncode({
+  'authorities': [
+    {
+      'type': 'AAD',
+      'audience': {'type': 'AzureADandPersonalMicrosoftAccount'},
+      'default': true,
+    }
+  ],
+  'authorization_user_agent': 'DEFAULT',
+  'multiple_clouds_supported': false,
+  'broker_redirect_uri_registered': false,
+  'http': {'connect_timeout': 10000, 'read_timeout': 30000},
+  'logging': {
+    'pii_enabled': false,
+    'log_level': 'WARNING',
+    'logcat_enabled': false,
+  },
+  'shared_device_mode_supported': false,
+  'account_mode': 'MULTIPLE',
+  'browser_safelist': [
+    {
+      'browser_package_name': 'com.android.chrome',
+      'browser_signature_hashes': ['aB1cD2eF3gH4iJ5kL6-mN7oP8qR=='],
+      'browser_use_customTab': true,
+      'browser_version_lower_bound': '45',
+    },
+    {
+      'browser_package_name': 'com.android.chrome',
+      'browser_signature_hashes': ['cD2eF3gH4iJ5kL6mN7-oP8qR9sT=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'org.mozilla.firefox',
+      'browser_signature_hashes': ['eF3gH4iJ5kL6mN7oP8-qR9sT0uV=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'org.mozilla.firefox',
+      'browser_signature_hashes': ['gH4iJ5kL6mN7oP8qR9-sT0uV1wX=='],
+      'browser_use_customTab': true,
+      'browser_version_lower_bound': '57',
+    },
+    {
+      'browser_package_name': 'com.sec.android.app.sbrowser',
+      'browser_signature_hashes': ['iJ5kL6mN7oP8qR9sT0-uV1wX2yZ=='],
+      'browser_use_customTab': true,
+      'browser_version_lower_bound': '4.0',
+    },
+    {
+      'browser_package_name': 'com.sec.android.app.sbrowser',
+      'browser_signature_hashes': ['kL6mN7oP8qR9sT0uV1-wX2yZ3aB=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.cloudmosa.puffinFree',
+      'browser_signature_hashes': ['mN7oP8qR9sT0uV1wX2-yZ3aB4dE='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.duckduckgo.mobile.android',
+      'browser_signature_hashes': ['S5Av4...jAi4Q=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.explore.web.browser',
+      'browser_signature_hashes': ['BzDzB...YHCag=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.ksmobile.cb',
+      'browser_signature_hashes': ['lFDYx...7nouw=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.microsoft.emmx',
+      'browser_signature_hashes': ['Ivy-R...A6fVQ=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.opera.browser',
+      'browser_signature_hashes': ['FIJ3I...jWJWw=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'com.opera.mini.native',
+      'browser_signature_hashes': ['TOTyH...mmUYQ=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'mobi.mgeek.TunnyBrowser',
+      'browser_signature_hashes': ['RMVoXgjjgyjjmbj4578fcbkyyQ=='],
+      'browser_use_customTab': false,
+    },
+    {
+      'browser_package_name': 'org.mozilla.focus',
+      'browser_signature_hashes': ['L72dT...q0oYA=='],
+      'browser_use_customTab': false,
+    }
+  ],
+});

--- a/test/single_account_pca_test.dart
+++ b/test/single_account_pca_test.dart
@@ -1,11 +1,33 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:msal_auth/msal_auth.dart';
 
+import 'data/test_data.dart';
 import 'utils/method_call_matcher.dart';
 import 'utils/widget_tester_extensions.dart';
 
 void main() {
+  const mockAndroidConfigPath = 'some_path/android_config.json';
+
+  tearDown(rootBundle.clear);
+
+  Future<SingleAccountPca> setupAndCreateAndroidPca(WidgetTester tester) async {
+    tester.mockRootBundleLoadString(
+      mockAndroidConfigPath,
+      androidConfigString,
+    );
+    return SingleAccountPca.create(
+      clientId: 'test',
+      androidConfig: AndroidConfig(
+        configFilePath: mockAndroidConfigPath,
+        redirectUri: 'testRedirectUri',
+      ),
+    );
+  }
+
   group('SingleAccountPca', () {
     group('create', () {
       testWidgets(
@@ -43,7 +65,7 @@ void main() {
       );
 
       testWidgets(
-        'invokes createSingleAccountPca with correct arguments',
+        'invokes createSingleAccountPca with correct arguments for iOS',
         variant: TargetPlatformVariant.only(TargetPlatform.iOS),
         (tester) async {
           MethodCall? methodCall;
@@ -77,8 +99,51 @@ void main() {
       );
 
       testWidgets(
+        'invokes createSingleAccountPca with correct arguments for Android',
+        (tester) async {
+          tester.mockRootBundleLoadString(
+            mockAndroidConfigPath,
+            androidConfigString,
+          );
+          final androidConfig =
+              jsonDecode(androidConfigString) as Map<String, dynamic>;
+          MethodCall? methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            return null;
+          });
+
+          final pca = await SingleAccountPca.create(
+            clientId: 'testId',
+            androidConfig: AndroidConfig(
+              configFilePath: mockAndroidConfigPath,
+              redirectUri: 'testRedirectUri',
+            ),
+          );
+          final expectedConfig = androidConfig
+            ..addAll({
+              'client_id': 'testId',
+              'redirect_uri': 'testRedirectUri',
+            });
+
+          expect(pca, isA<SingleAccountPca>());
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall(
+                'createSingleAccountPca',
+                <String, dynamic>{
+                  'config': expectedConfig,
+                },
+              ),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
         'converts PlatformException to MsalException exception '
-        'and throws it',
+        'and throws it for iOS',
         variant: TargetPlatformVariant.only(TargetPlatform.iOS),
         (tester) async {
           tester.setMockMethodCallHandler((call) async {
@@ -102,11 +167,36 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'converts PlatformException to MsalException exception '
+        'and throws it for Android',
+        (tester) async {
+          tester
+            ..mockRootBundleLoadString(
+              mockAndroidConfigPath,
+              androidConfigString,
+            )
+            ..setMockMethodCallHandler((call) async {
+              throw PlatformException(code: 'test', message: 'test');
+            });
+          expect(
+            () => SingleAccountPca.create(
+              clientId: 'test',
+              androidConfig: AndroidConfig(
+                configFilePath: mockAndroidConfigPath,
+                redirectUri: 'testRedirectUri',
+              ),
+            ),
+            throwsA(isA<MsalException>()),
+          );
+        },
+      );
     });
 
     group('currentAccount', () {
       testWidgets(
-        'calls currentAccount and returns Account',
+        'calls currentAccount and returns Account on iOS',
         variant: TargetPlatformVariant.only(TargetPlatform.iOS),
         (tester) async {
           MethodCall? methodCall;
@@ -138,8 +228,40 @@ void main() {
       );
 
       testWidgets(
+        'calls currentAccount and returns Account on Android',
+        (tester) async {
+          MethodCall? methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            if (call.method == 'currentAccount') {
+              return <String, dynamic>{
+                'id': 'testId',
+                'username': 'testUsername',
+                'name': 'testName',
+              };
+            }
+            return null;
+          });
+
+          final pca = await setupAndCreateAndroidPca(tester);
+          final account = await pca.currentAccount;
+
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall('currentAccount'),
+            ),
+          );
+
+          expect(account.id, 'testId');
+          expect(account.username, 'testUsername');
+          expect(account.name, 'testName');
+        },
+      );
+
+      testWidgets(
         'converts PlatformException to MsalException exception '
-        'and throws it',
+        'and throws it on iOS',
         variant: TargetPlatformVariant.only(TargetPlatform.iOS),
         (tester) async {
           tester.setMockMethodCallHandler((call) async {
@@ -165,44 +287,45 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'converts PlatformException to MsalException exception '
+        'and throws it on Android',
+        (tester) async {
+          tester.setMockMethodCallHandler((call) async {
+            if (call.method == 'currentAccount') {
+              throw PlatformException(code: 'test', message: 'test');
+            }
+            return null;
+          });
+
+          final pca = await setupAndCreateAndroidPca(tester);
+
+          expect(
+            pca.currentAccount,
+            throwsA(
+              isA<MsalException>().having(
+                (e) => e.message,
+                'message',
+                'test',
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('signOut', () {
+      final signOutResult = ValueVariant<bool>({true, false});
       testWidgets(
-        'signs out current account successfully',
-        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        'returns native signOut result on iOS',
+        variant: signOutResult,
         (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
           late MethodCall methodCall;
           tester.setMockMethodCallHandler((call) async {
             methodCall = call;
-            return true;
-          });
-
-          final pca = await SingleAccountPca.create(
-            clientId: 'test',
-            iosConfig: IosConfig(),
-          );
-          final result = await pca.signOut();
-
-          expect(
-            methodCall,
-            equalsMethodCall(
-              MethodCall('signOut'),
-            ),
-          );
-
-          expect(result, true);
-        },
-      );
-
-      testWidgets(
-        'returns false if native signOut returns false',
-        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-        (tester) async {
-          late MethodCall methodCall;
-          tester.setMockMethodCallHandler((call) async {
-            methodCall = call;
-            return false;
+            return signOutResult.currentValue!;
           });
 
           final pca = await SingleAccountPca.create(
@@ -215,12 +338,13 @@ void main() {
             methodCall,
             equalsMethodCall(MethodCall('signOut')),
           );
-          expect(result, false);
+          expect(result, signOutResult.currentValue!);
+          debugDefaultTargetPlatformOverride = null;
         },
       );
 
       testWidgets(
-        'converts PlatformException to MsalException and throws it',
+        'converts PlatformException to MsalException and throws it on iOS',
         variant: TargetPlatformVariant.only(TargetPlatform.iOS),
         (tester) async {
           tester.setMockMethodCallHandler((call) async {
@@ -234,6 +358,56 @@ void main() {
             clientId: 'test',
             iosConfig: IosConfig(),
           );
+
+          expect(
+            pca.signOut,
+            throwsA(
+              isA<MsalException>().having(
+                (e) => e.message,
+                'message',
+                'test',
+              ),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'returns native signOut result on Android',
+        variant: signOutResult,
+        (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+          late MethodCall methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            if (call.method == 'signOut') return signOutResult.currentValue!;
+            return null;
+          });
+
+          final pca = await setupAndCreateAndroidPca(tester);
+          final result = await pca.signOut();
+
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall('signOut'),
+            ),
+          );
+          expect(result, signOutResult.currentValue!);
+          debugDefaultTargetPlatformOverride = null;
+        },
+      );
+
+      testWidgets(
+        'converts PlatformException to MsalException and throws it on Android',
+        (tester) async {
+          tester.setMockMethodCallHandler((call) async {
+            if (call.method == 'signOut') {
+              throw PlatformException(code: 'test', message: 'test');
+            }
+            return null;
+          });
+          final pca = await setupAndCreateAndroidPca(tester);
 
           expect(
             pca.signOut,

--- a/test/single_account_pca_test.dart
+++ b/test/single_account_pca_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:msal_auth/msal_auth.dart';
+
+import 'utils/method_call_matcher.dart';
+import 'utils/widget_tester_extensions.dart';
+
+void main() {
+  group('SingleAccountPca', () {
+    group('create', () {
+      testWidgets(
+        'throws AssertionError if androidConfig is null on Android platform',
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+        (tester) async {
+          expect(
+            () => SingleAccountPca.create(clientId: 'test'),
+            throwsA(
+              isA<AssertionError>().having(
+                (e) => e.message,
+                'message',
+                'Android config can not be null',
+              ),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'throws AssertionError if iosConfig is null on iOS platform',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          expect(
+            () => SingleAccountPca.create(clientId: 'test'),
+            throwsA(
+              isA<AssertionError>().having(
+                (e) => e.message,
+                'message',
+                'iOS config can not be null',
+              ),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'invokes createSingleAccountPca with correct arguments',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          MethodCall? methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            return null;
+          });
+          final pca = await SingleAccountPca.create(
+            clientId: 'testId',
+            iosConfig: IosConfig(
+              authority: 'testAuthority',
+            ),
+          );
+
+          expect(pca, isA<SingleAccountPca>());
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall(
+                'createSingleAccountPca',
+                <String, dynamic>{
+                  'clientId': 'testId',
+                  'authority': 'testAuthority',
+                  'broker': 'msAuthenticator',
+                  'authorityType': 'aad',
+                },
+              ),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'converts PlatformException to MsalException exception '
+        'and throws it',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          tester.setMockMethodCallHandler((call) async {
+            throw PlatformException(
+              code: 'test',
+              message: 'test',
+            );
+          });
+          expect(
+            () => SingleAccountPca.create(
+              clientId: 'test',
+              iosConfig: IosConfig(),
+            ),
+            throwsA(
+              isA<MsalException>().having(
+                (e) => e.message,
+                'message',
+                'test',
+              ),
+            ),
+          );
+        },
+      );
+    });
+
+    group('currentAccount', () {
+      testWidgets(
+        'calls currentAccount and returns Account',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          MethodCall? methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            return <String, dynamic>{
+              'id': 'testId',
+              'username': 'testUsername',
+              'name': 'testName',
+            };
+          });
+          final pca = await SingleAccountPca.create(
+            clientId: 'test',
+            iosConfig: IosConfig(),
+          );
+          final account = await pca.currentAccount;
+
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall('currentAccount'),
+            ),
+          );
+
+          expect(account.id, 'testId');
+          expect(account.username, 'testUsername');
+          expect(account.name, 'testName');
+        },
+      );
+
+      testWidgets(
+        'converts PlatformException to MsalException exception '
+        'and throws it',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          tester.setMockMethodCallHandler((call) async {
+            if (call.method == 'currentAccount') {
+              throw PlatformException(code: 'test', message: 'test');
+            }
+            return null;
+          });
+          final pca = await SingleAccountPca.create(
+            clientId: 'test',
+            iosConfig: IosConfig(),
+          );
+
+          expect(
+            pca.currentAccount,
+            throwsA(
+              isA<MsalException>().having(
+                (e) => e.message,
+                'message',
+                'test',
+              ),
+            ),
+          );
+        },
+      );
+    });
+
+    group('signOut', () {
+      testWidgets(
+        'signs out current account successfully',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          late MethodCall methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            return true;
+          });
+
+          final pca = await SingleAccountPca.create(
+            clientId: 'test',
+            iosConfig: IosConfig(),
+          );
+          final result = await pca.signOut();
+
+          expect(
+            methodCall,
+            equalsMethodCall(
+              MethodCall('signOut'),
+            ),
+          );
+
+          expect(result, true);
+        },
+      );
+
+      testWidgets(
+        'returns false if native signOut returns false',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          late MethodCall methodCall;
+          tester.setMockMethodCallHandler((call) async {
+            methodCall = call;
+            return false;
+          });
+
+          final pca = await SingleAccountPca.create(
+            clientId: 'test',
+            iosConfig: IosConfig(),
+          );
+          final result = await pca.signOut();
+
+          expect(
+            methodCall,
+            equalsMethodCall(MethodCall('signOut')),
+          );
+          expect(result, false);
+        },
+      );
+
+      testWidgets(
+        'converts PlatformException to MsalException and throws it',
+        variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+        (tester) async {
+          tester.setMockMethodCallHandler((call) async {
+            if (call.method == 'signOut') {
+              throw PlatformException(code: 'test', message: 'test');
+            }
+            return null;
+          });
+
+          final pca = await SingleAccountPca.create(
+            clientId: 'test',
+            iosConfig: IosConfig(),
+          );
+
+          expect(
+            pca.signOut,
+            throwsA(
+              isA<MsalException>().having(
+                (e) => e.message,
+                'message',
+                'test',
+              ),
+            ),
+          );
+        },
+      );
+    });
+  });
+}

--- a/test/utils/method_call_matcher.dart
+++ b/test/utils/method_call_matcher.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Matcher equalsMethodCall(MethodCall method) {
+  return MethodCallMatcher(method);
+}
+
+class MethodCallMatcher extends Matcher {
+  const MethodCallMatcher(this.method);
+
+  final MethodCall method;
+
+  @override
+  bool matches(Object? expectedMethod, Map<dynamic, dynamic> matchState) {
+    return expectedMethod is MethodCall &&
+        expectedMethod.method == method.method &&
+        mapsEqual(expectedMethod.arguments, method.arguments);
+  }
+
+  @override
+  Description describe(Description description) {
+    return description.add('method call $method');
+  }
+
+  @override
+  Description describeMismatch(
+    Object? expectedMethod,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
+    if (expectedMethod is! MethodCall) {
+      return mismatchDescription.add(
+        'expected MethodCall, but was ${expectedMethod.runtimeType}',
+      );
+    }
+
+    if (expectedMethod.method != method.method) {
+      return mismatchDescription.add(
+        'expected method ${method.method}, but was ${expectedMethod.method}',
+      );
+    }
+
+    if (!mapsEqual(expectedMethod.arguments, method.arguments)) {
+      return mismatchDescription.add(
+        'expected arguments ${method.arguments}, '
+        'but was ${expectedMethod.arguments}',
+      );
+    }
+
+    return mismatchDescription.add(
+      'expected $method, but was $expectedMethod',
+    );
+  }
+}
+
+/// Helper function to compare maps for equality.
+bool mapsEqual(Map? map1, Map? map2) {
+  if (identical(map1, map2)) return true;
+  if (map1 == null || map2 == null) return map1 == map2;
+  if (map1.length != map2.length) return false;
+
+  for (final key in map1.keys) {
+    if (!map2.containsKey(key)) return false;
+
+    final value1 = map1[key];
+    final value2 = map2[key];
+
+    if (value1 is Map && value2 is Map) {
+      if (!mapsEqual(value1, value2)) return false;
+    } else if (value1 != value2) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/utils/method_call_matcher.dart
+++ b/test/utils/method_call_matcher.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,7 +15,8 @@ class MethodCallMatcher extends Matcher {
   bool matches(Object? expectedMethod, Map<dynamic, dynamic> matchState) {
     return expectedMethod is MethodCall &&
         expectedMethod.method == method.method &&
-        mapsEqual(expectedMethod.arguments, method.arguments);
+        DeepCollectionEquality()
+            .equals(expectedMethod.arguments, method.arguments);
   }
 
   @override
@@ -41,7 +43,8 @@ class MethodCallMatcher extends Matcher {
       );
     }
 
-    if (!mapsEqual(expectedMethod.arguments, method.arguments)) {
+    if (!DeepCollectionEquality()
+        .equals(expectedMethod.arguments, method.arguments)) {
       return mismatchDescription.add(
         'expected arguments ${method.arguments}, '
         'but was ${expectedMethod.arguments}',
@@ -52,26 +55,4 @@ class MethodCallMatcher extends Matcher {
       'expected $method, but was $expectedMethod',
     );
   }
-}
-
-/// Helper function to compare maps for equality.
-bool mapsEqual(Map? map1, Map? map2) {
-  if (identical(map1, map2)) return true;
-  if (map1 == null || map2 == null) return map1 == map2;
-  if (map1.length != map2.length) return false;
-
-  for (final key in map1.keys) {
-    if (!map2.containsKey(key)) return false;
-
-    final value1 = map1[key];
-    final value2 = map2[key];
-
-    if (value1 is Map && value2 is Map) {
-      if (!mapsEqual(value1, value2)) return false;
-    } else if (value1 != value2) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/test/utils/method_call_matcher_test.dart
+++ b/test/utils/method_call_matcher_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'method_call_matcher.dart';
+
+void main() {
+  test('equalsMethodCall', () {
+    expect(
+      MethodCall('test'),
+      equalsMethodCall(MethodCall('test')),
+    );
+
+    expect(
+      MethodCall('test', <String, dynamic>{'test': 'test'}),
+      equalsMethodCall(MethodCall('test', <String, dynamic>{'test': 'test'})),
+    );
+
+    expect(
+      MethodCall('test'),
+      isNot(equalsMethodCall(MethodCall('test2'))),
+    );
+
+    expect(
+      MethodCall('test', <String, dynamic>{'test': 'test'}),
+      isNot(equalsMethodCall(MethodCall('test'))),
+    );
+
+    expect(
+      MethodCall('test'),
+      isNot(equalsMethodCall(MethodCall('test', <String, dynamic>{}))),
+    );
+
+    expect(
+      'test',
+      isNot(equalsMethodCall(MethodCall('test'))),
+    );
+
+    expect(
+      MethodCall('test', <String, dynamic>{
+        'test': 'test',
+      }),
+      isNot(
+        equalsMethodCall(
+          MethodCall('test', <String, dynamic>{
+            'test2': 'test2',
+          }),
+        ),
+      ),
+    );
+  });
+}

--- a/test/utils/widget_tester_extensions.dart
+++ b/test/utils/widget_tester_extensions.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:msal_auth/msal_auth.dart';
+
+extension WidgetTesterX on WidgetTester {
+  Future<void> setMockMethodCallHandler(
+    Future<dynamic> Function(MethodCall) handler,
+  ) async {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      kMethodChannel,
+      handler,
+    );
+  }
+}

--- a/test/utils/widget_tester_extensions.dart
+++ b/test/utils/widget_tester_extensions.dart
@@ -3,12 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:msal_auth/msal_auth.dart';
 
 extension WidgetTesterX on WidgetTester {
-  Future<void> setMockMethodCallHandler(
+  void setMockMethodCallHandler(
     Future<dynamic> Function(MethodCall) handler,
-  ) async {
+  ) {
     binding.defaultBinaryMessenger.setMockMethodCallHandler(
       kMethodChannel,
       handler,
+    );
+  }
+
+  void mockRootBundleLoadString(String path, String content) {
+    binding.defaultBinaryMessenger.setMockMessageHandler(
+      'flutter/assets',
+      (message) async => Future.value(
+        ByteData.sublistView(Uint8List.fromList(content.codeUnits)),
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR adds tests for Single Account PCA.

They are a prerequisite to ensure everything keeps working when making refactorings while adding browser support.

A future PR will add tests for Multiple Account PCA.