### PR TITLE
Ref!: Allow different implementations per Platform

### DIFF
--- a/lib/msal_auth.dart
+++ b/lib/msal_auth.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/services.dart';
 
+export 'src/core/multiple_account_pca.dart';
 export 'src/core/public_client_application.dart';
+export 'src/core/single_account_pca.dart';
 export 'src/models/models.dart';
 
 const kMethodChannel = MethodChannel('msal_auth');

--- a/lib/src/core/mobile/mobile_multiple_account_pca.dart
+++ b/lib/src/core/mobile/mobile_multiple_account_pca.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/services.dart';
+
+import '../../../msal_auth.dart';
+import '../../utils/extensions.dart';
+import '../../utils/utils.dart';
+import '../platform_multiple_account_pca.dart';
+import 'mobile_public_client_application.dart';
+
+/// This class is used to create public client application for multiple account
+/// mode.
+final class MobileMultipleAccountPca extends MobilePublicClientApplication
+    implements PlatformMultipleAccountPca {
+  MobileMultipleAccountPca._create();
+
+  /// Creates multiple account public client application.
+  static Future<MobileMultipleAccountPca> create({
+    /// Client id of the application.
+    required String clientId,
+
+    /// Android configuration, required for android platform.
+    AndroidConfig? androidConfig,
+
+    /// iOS configuration, required for iOS platform.
+    IosConfig? iosConfig,
+  }) async {
+    final arguments = await Utils.createPcaArguments(
+      clientId: clientId,
+      androidConfig: androidConfig,
+      iosConfig: iosConfig,
+    );
+    try {
+      await kMethodChannel.invokeMethod('createMultipleAccountPca', arguments);
+      return MobileMultipleAccountPca._create();
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Gets the account from the cache by using given identifier.
+  /// if no account is available, it will throw an exception.
+  @override
+  Future<Account> getAccount({required String identifier}) async {
+    try {
+      final result =
+          await kMethodChannel.invokeMethod('getAccount', identifier);
+      return Account.fromJson(result.cast<String, dynamic>());
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Asynchronously returns a list of [Account] objects for which
+  /// this application has refresh tokens.
+  @override
+  Future<List<Account>> getAccounts() async {
+    try {
+      final result = await kMethodChannel.invokeMethod('getAccounts') as List;
+      return result
+          .map((account) => Account.fromJson(account.cast<String, dynamic>()))
+          .toList();
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Removes the account and credentials (tokens) for the given identifier.
+  @override
+  Future<bool> removeAccount({required String identifier}) async {
+    try {
+      final result =
+          await kMethodChannel.invokeMethod('removeAccount', identifier);
+      return result;
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+}

--- a/lib/src/core/mobile/mobile_public_client_application.dart
+++ b/lib/src/core/mobile/mobile_public_client_application.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/services.dart';
+
+import '../../../msal_auth.dart';
+import '../../utils/extensions.dart';
+
+/// This is the super class for MSAL public client application. developer
+/// should use the child classes to create the app based on the need.
+class MobilePublicClientApplication extends PublicClientApplication {
+  MobilePublicClientApplication();
+
+  /// Acquire token interactively, will pop-up webUI. this flow is called as
+  /// Interactive flow and so it skips the cache lookup.
+  @override
+  Future<AuthenticationResult> acquireToken({
+    /// Access levels your application is requesting from the
+    /// Microsoft identity platform on behalf of a user.
+    required List<String> scopes,
+
+    /// Initial UI option.
+    Prompt prompt = Prompt.whenRequired,
+
+    /// It should be valid "email id" or "username" or "unique identifier".
+    /// Value is used as an identity provider to pre-fill a user's
+    /// email address or username in the login form.
+    String? loginHint,
+  }) async {
+    assert(scopes.isNotEmpty, 'Scopes can not be empty');
+    final arguments = <String, dynamic>{
+      'scopes': scopes,
+      'prompt': prompt.name,
+      'loginHint': loginHint,
+      'broker': Broker.msAuthenticator.name,
+    };
+    try {
+      final result =
+          await kMethodChannel.invokeMethod('acquireToken', arguments);
+      return AuthenticationResult.fromJson(result.cast<String, dynamic>());
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Perform acquire token silent call. If there is a valid access token in
+  /// the cache, the sdk will return the access token; If no valid access token
+  /// exists, the sdk will try to find a refresh token and use the refresh token
+  /// to get a new access token. If refresh token does not exist or it fails
+  /// the refresh, exception will be sent.
+  @override
+  Future<AuthenticationResult> acquireTokenSilent({
+    /// Access levels your application is requesting from the
+    /// Microsoft identity platform on behalf of a user.
+    required List<String> scopes,
+
+    /// Account identifier, basically id from account object.
+    /// Required for multiple account mode.
+    String? identifier,
+  }) async {
+    assert(scopes.isNotEmpty, 'Scopes can not be empty');
+    final arguments = <String, dynamic>{
+      'scopes': scopes,
+      'identifier': identifier,
+    };
+    try {
+      final result =
+          await kMethodChannel.invokeMethod('acquireTokenSilent', arguments);
+      return AuthenticationResult.fromJson(result.cast<String, dynamic>());
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+}

--- a/lib/src/core/mobile/mobile_single_account_pca.dart
+++ b/lib/src/core/mobile/mobile_single_account_pca.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/services.dart';
+
+import '../../../msal_auth.dart';
+import '../../utils/extensions.dart';
+import '../../utils/utils.dart';
+import '../platform_single_account_pca.dart';
+import 'mobile_public_client_application.dart';
+
+/// This class is used to create public client application for single account
+/// mode.
+final class MobileSingleAccountPca extends MobilePublicClientApplication
+    implements PlatformSingleAccountPca {
+  MobileSingleAccountPca._create();
+
+  /// Creates single account public client application.
+  static Future<MobileSingleAccountPca> create({
+    /// Client id of the application.
+    required String clientId,
+
+    /// Android configuration, required for android platform.
+    AndroidConfig? androidConfig,
+
+    /// iOS configuration, required for iOS platform.
+    IosConfig? iosConfig,
+  }) async {
+    try {
+      final arguments = await Utils.createPcaArguments(
+        clientId: clientId,
+        androidConfig: androidConfig,
+        iosConfig: iosConfig,
+      );
+      await kMethodChannel.invokeMethod('createSingleAccountPca', arguments);
+      return MobileSingleAccountPca._create();
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Gets the current account from the cache. if no account is available, it
+  /// will throw an exception.
+  @override
+  Future<Account> get currentAccount async {
+    try {
+      final result = await kMethodChannel.invokeMethod('currentAccount');
+      return Account.fromJson(result.cast<String, dynamic>());
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+
+  /// Signs out the current account and credentials (tokens).
+  /// NOTE: If a device is marked as a shared device within broker,
+  /// sign out will be device wide.
+  @override
+  Future<bool> signOut() async {
+    try {
+      final result = await kMethodChannel.invokeMethod('signOut');
+      return result;
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
+}

--- a/lib/src/core/platform_multiple_account_pca.dart
+++ b/lib/src/core/platform_multiple_account_pca.dart
@@ -1,0 +1,7 @@
+import '../../msal_auth.dart';
+
+abstract class PlatformMultipleAccountPca extends PublicClientApplication {
+  Future<Account> getAccount({required String identifier});
+  Future<List<Account>> getAccounts();
+  Future<bool> removeAccount({required String identifier});
+}

--- a/lib/src/core/platform_single_account_pca.dart
+++ b/lib/src/core/platform_single_account_pca.dart
@@ -1,0 +1,6 @@
+import '../../msal_auth.dart';
+
+abstract class PlatformSingleAccountPca extends PublicClientApplication {
+  Future<Account> get currentAccount;
+  Future<bool> signOut();
+}

--- a/lib/src/core/single_account_pca.dart
+++ b/lib/src/core/single_account_pca.dart
@@ -1,54 +1,70 @@
-part of 'public_client_application.dart';
+import 'package:flutter/foundation.dart';
 
-/// This class is used to create public client application for single account
-/// mode.
-final class SingleAccountPca extends PublicClientApplication {
-  SingleAccountPca._create();
+import '../../msal_auth.dart';
+import 'mobile/mobile_single_account_pca.dart';
+import 'platform_single_account_pca.dart';
+import 'web/web_single_account_pca.dart';
 
-  /// Creates single account public client application.
+final class SingleAccountPca implements PlatformSingleAccountPca {
+  SingleAccountPca._create(this._delegate);
+
+  final PlatformSingleAccountPca _delegate;
+
   static Future<SingleAccountPca> create({
-    /// Client id of the application.
     required String clientId,
-
-    /// Android configuration, required for android platform.
     AndroidConfig? androidConfig,
-
-    /// iOS configuration, required for iOS platform.
     IosConfig? iosConfig,
   }) async {
-    try {
-      final arguments = await Utils.createPcaArguments(
-        clientId: clientId,
-        androidConfig: androidConfig,
-        iosConfig: iosConfig,
-      );
-      await kMethodChannel.invokeMethod('createSingleAccountPca', arguments);
-      return SingleAccountPca._create();
-    } on PlatformException catch (e) {
-      throw e.convertToMsalException();
-    }
+    final pca = kIsWeb
+        ? await WebSingleAccountPca.create()
+        : await MobileSingleAccountPca.create(
+            clientId: clientId,
+            androidConfig: androidConfig,
+            iosConfig: iosConfig,
+          );
+    return SingleAccountPca._create(pca);
   }
+
+  @override
+  Future<AuthenticationResult> acquireToken({
+    /// Access levels your application is requesting from the
+    /// Microsoft identity platform on behalf of a user.
+    required List<String> scopes,
+
+    /// Initial UI option.
+    Prompt prompt = Prompt.whenRequired,
+
+    /// It should be valid "email id" or "username" or "unique identifier".
+    /// Value is used as an identity provider to pre-fill a user's
+    /// email address or username in the login form.
+    String? loginHint,
+  }) =>
+      _delegate.acquireToken(
+        scopes: scopes,
+        prompt: prompt,
+        loginHint: loginHint,
+      );
+
+  @override
+  Future<AuthenticationResult> acquireTokenSilent({
+    /// Access levels your application is requesting from the
+    /// Microsoft identity platform on behalf of a user.
+    required List<String> scopes,
+
+    /// Account identifier, basically id from account object.
+    /// Required for multiple account mode.
+    String? identifier,
+  }) =>
+      _delegate.acquireTokenSilent(scopes: scopes, identifier: identifier);
 
   /// Gets the current account from the cache. if no account is available, it
   /// will throw an exception.
-  Future<Account> get currentAccount async {
-    try {
-      final result = await kMethodChannel.invokeMethod('currentAccount');
-      return Account.fromJson(result.cast<String, dynamic>());
-    } on PlatformException catch (e) {
-      throw e.convertToMsalException();
-    }
-  }
+  @override
+  Future<Account> get currentAccount => _delegate.currentAccount;
 
   /// Signs out the current account and credentials (tokens).
   /// NOTE: If a device is marked as a shared device within broker,
   /// sign out will be device wide.
-  Future<bool> signOut() async {
-    try {
-      final result = await kMethodChannel.invokeMethod('signOut');
-      return result;
-    } on PlatformException catch (e) {
-      throw e.convertToMsalException();
-    }
-  }
+  @override
+  Future<bool> signOut() => _delegate.signOut();
 }

--- a/lib/src/core/web/web_multiple_platform_pca.dart
+++ b/lib/src/core/web/web_multiple_platform_pca.dart
@@ -1,0 +1,23 @@
+import '../../../msal_auth.dart';
+import '../platform_multiple_account_pca.dart';
+import 'web_public_client_application.dart';
+
+final class WebMultipleAccountPca extends WebPublicClientApplication
+    implements PlatformMultipleAccountPca {
+  WebMultipleAccountPca._create();
+
+  static Future<WebMultipleAccountPca> create() async {
+    return WebMultipleAccountPca._create();
+  }
+
+  @override
+  Future<Account> getAccount({required String identifier}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<Account>> getAccounts() => throw UnimplementedError();
+
+  @override
+  Future<bool> removeAccount({required String identifier}) =>
+      throw UnimplementedError();
+}

--- a/lib/src/core/web/web_public_client_application.dart
+++ b/lib/src/core/web/web_public_client_application.dart
@@ -1,6 +1,7 @@
-import '../../msal_auth.dart';
+import '../../../msal_auth.dart';
 
-abstract class PublicClientApplication {
+class WebPublicClientApplication extends PublicClientApplication {
+  @override
   Future<AuthenticationResult> acquireToken({
     /// Access levels your application is requesting from the
     /// Microsoft identity platform on behalf of a user.
@@ -13,8 +14,10 @@ abstract class PublicClientApplication {
     /// Value is used as an identity provider to pre-fill a user's
     /// email address or username in the login form.
     String? loginHint,
-  });
+  }) =>
+      throw UnimplementedError();
 
+  @override
   Future<AuthenticationResult> acquireTokenSilent({
     /// Access levels your application is requesting from the
     /// Microsoft identity platform on behalf of a user.
@@ -23,5 +26,6 @@ abstract class PublicClientApplication {
     /// Account identifier, basically id from account object.
     /// Required for multiple account mode.
     String? identifier,
-  });
+  }) =>
+      throw UnimplementedError();
 }

--- a/lib/src/core/web/web_single_account_pca.dart
+++ b/lib/src/core/web/web_single_account_pca.dart
@@ -1,0 +1,18 @@
+import '../../../msal_auth.dart';
+import '../platform_single_account_pca.dart';
+import 'web_public_client_application.dart';
+
+final class WebSingleAccountPca extends WebPublicClientApplication
+    implements PlatformSingleAccountPca {
+  WebSingleAccountPca._create();
+
+  static Future<WebSingleAccountPca> create() async {
+    return WebSingleAccountPca._create();
+  }
+
+  @override
+  Future<Account> get currentAccount => throw UnimplementedError();
+
+  @override
+  Future<bool> signOut() => throw UnimplementedError();
+}


### PR DESCRIPTION
This PR refactors the core classes. It contains a **BREAKING CHANGE**.

It make `PublicClientApplication` abstract, and introduces`PlatformSingleAccountPca` and `PlatformMultipleAccountPca` abstract classes that can be implemented for a given platform. 

The existing implementations for Single and Multiple Account Pca were moved to `MobileSingleAccountPca` and `MobileMultipleAccountPca` to allow for a web implementation.

The web implementations `WebSingleAccountPca` and `WebMultipleAccountPca` are currently merely stubs and will be implemented in future PRs. 

This is a **BREAKING CHANGE**, because the `PublicClientApplication` is now an abstract class and is implemented depending on the platform. 

The interfaces for `SingleAccountPca` and `MultipleAccountPca` stayed the same and can be used as before.


This is my best shot at opening up the possibilities of platform-specific implementations while keeping breaking changes at a minimum. 

I'm open to discussing better approaches if you have any in mind.

Also, feel free to merge all branches where tests are added into the `feat/msal-js` branch. Then I can rebase this one and we can run the tests to ensure everything still works. 