### PR TITLE
Feat: Add js interop for web auth

### DIFF
--- a/assets/js/msalv3.js
+++ b/assets/js/msalv3.js
@@ -4,65 +4,30 @@
 
 // Needs to be a var at the top level to get hoisted to global scope.
 // https://stackoverflow.com/questions/28776079/do-let-statements-create-properties-on-the-global-object/28776236#28776236
+
 var msalAuth = (function () {
   let msalObject = null;
-  let authResult = null;
   let redirectHandlerTask = null;
 
-  const tokenRequest = {
-    scopes: null,
-    prompt: null,
-    extraQueryParameters: {},
-    loginHint: null,
-  };
-
-  // Initialise the msalObject for the given client, authority and scope
   async function init(config) {
     var authData = {
       clientId: config.clientId,
       authority: config.isB2C
-        ? "https://" +
-          config.tenant +
-          ".b2clogin.com/tfp/" +
-          config.tenant +
-          ".onmicrosoft.com/" +
-          config.policy +
-          "/"
-        : "https://login.microsoftonline.com/" + config.tenant,
+        ? `https://${config.tenant}.b2clogin.com/tfp/${config.tenant}.onmicrosoft.com/${config.policy}/`
+        : `https://login.microsoftonline.com/${config.tenant}`,
       knownAuthorities: [
-        config.tenant + ".b2clogin.com",
+        `${config.tenant}.b2clogin.com`,
         "login.microsoftonline.com",
       ],
       redirectUri: config.redirectUri,
     };
-    var postLogoutRedirectUri = {
-      postLogoutRedirectUri: config.postLogoutRedirectUri,
-    };
     var msalConfig = {
-      auth:
-        config?.postLogoutRedirectUri == null
-          ? {
-              ...authData,
-            }
-          : {
-              ...authData,
-              ...postLogoutRedirectUri,
-            },
+      auth: authData,
       cache: {
         cacheLocation: config.cacheLocation,
         storeAuthStateInCookie: false,
       },
     };
-
-    if (typeof config.scope === "string") {
-      tokenRequest.scopes = config.scope.split(" ");
-    } else {
-      tokenRequest.scopes = config.scope;
-    }
-
-    tokenRequest.extraQueryParameters = JSON.parse(config.customParameters);
-    tokenRequest.prompt = config.prompt;
-    tokenRequest.loginHint = config.loginHint;
 
     msalObject =
       await msal.PublicClientApplication.createPublicClientApplication(
@@ -74,213 +39,78 @@ var msalAuth = (function () {
     redirectHandlerTask = msalObject.handleRedirectPromise();
   }
 
+  async function acquireToken(scopes, prompt, loginHint, useRedirect) {
+    let parameters = {
+      scopes: scopes,
+      prompt: prompt,
+      loginHint: loginHint,
+    };
+
+    if (useRedirect) {
+      msalObject.acquireTokenRedirect(parameters);
+    } else {
+      return await msalObject.loginPopup(parameters);
+    }
+  }
+
   // Tries to silently acquire a token. Will return null if a token
   // could not be acquired or if no cached account credentials exist.
-  // Will return the authentication result on success and update the
-  // global authResult variable.
-  async function silentlyAcquireToken() {
-    try {
-      // The redirect handler task will complete with auth results if we
-      // were redirected from AAD. If not, it will complete with null
-      // We must wait for it to complete before we allow the login to
-      // attempt to acquire a token silently, and then progress to interactive
-      // login (if silent acquisition fails).
-      let result = await redirectHandlerTask;
-      if (result !== null) {
-        authResult = result;
-        return authResult;
-      }
-    } catch (error) {
-      authResultError = null;
+  // Will return the authentication result on success.
+  async function acquireTokenSilent(scopes, identifier) {
+    // The redirect handler task will complete with auth results if we
+    // were redirected from AAD. If not, it will complete with null
+    // We must wait for it to complete before we attempt to acquire a token silently.
+    let result = await redirectHandlerTask;
+    if (result !== null) {
+      return result;
     }
 
-    const account = getAccount();
+    const account = getAccount(identifier);
     if (account == null) {
       return null;
     }
 
-    try {
-      // Silent acquisition only works if the access token is either
-      // within its lifetime, or the refresh token can successfully be
-      // used to refresh it. This will throw if the access token can't
-      // be acquired.
-      const silentAuthResult = await msalObject.acquireTokenSilent({
-        scopes: tokenRequest.scopes,
-        prompt: "none",
-        account: account,
-        extraQueryParameters: tokenRequest.extraQueryParameters,
-      });
+    const silentAuthResult = await msalObject.acquireTokenSilent({
+      scopes: scopes,
+      prompt: "none",
+      account: account,
+    });
 
-      return (authResult = silentAuthResult);
-    } catch (error) {
-      console.log("Unable to silently acquire a new token: " + error.message);
-      return null;
-    }
+    return silentAuthResult;
   }
 
-  /// Authorize user via refresh token or web gui if necessary.
-  ///
-  /// Setting [refreshIfAvailable] to [true] should attempt to re-authenticate
-  /// with the existing refresh token, if any, even though the access token may
-  /// still be valid; however MSAL doesn't support this. Therefore it will have
-  /// the same impact as when it is set to [false].
-  /// [useRedirect] uses the MSAL redirection based token acquisition instead of
-  /// a popup window. This is the only way that iOS based devices will acquire
-  /// a token using MSAL when the application is installed to the home screen.
-  /// This is because the popup window operates outside the sandbox of the PWA and
-  /// won't share cookies or local storage with the PWA sandbox. Redirect flow works
-  /// around this issue by having the MSAL authentication take place directly within
-  /// the PWA sandbox browser.
-  /// The token is requested using acquireTokenSilent, which will refresh the token
-  /// if it has nearly expired. If this fails for any reason, it will then move on
-  /// to attempt to refresh the token using an interactive login.
-
-  async function login(refreshIfAvailable, useRedirect, onSuccess, onError) {
-    // Try to sign in silently, assuming we have already signed in and have
-    // a cached access token
-    await silentlyAcquireToken();
-
-    if (authResult != null) {
-      // Skip interactive login
-      onSuccess(authResult.accessToken ?? null);
-      return;
-    }
-
-    const account = getAccount();
-
-    if (useRedirect) {
-      msalObject.acquireTokenRedirect({
-        scopes: tokenRequest.scopes,
-        prompt: tokenRequest.prompt,
-        account: account,
-        extraQueryParameters: tokenRequest.extraQueryParameters,
-        loginHint: tokenRequest.loginHint,
-      });
-    } else {
-      // Sign in with popup
-      try {
-        const interactiveAuthResult = await msalObject.loginPopup({
-          scopes: tokenRequest.scopes,
-          prompt: tokenRequest.prompt,
-          account: account,
-          extraQueryParameters: tokenRequest.extraQueryParameters,
-          loginHint: tokenRequest.loginHint,
-        });
-
-        authResult = interactiveAuthResult;
-
-        onSuccess(authResult.accessToken ?? null);
-      } catch (error) {
-        // rethrow
-        console.warn(error.message);
-        onError(error);
-      }
-    }
+  function getAccount(identifier) {
+    const accountFilter = {
+      homeAccountId: identifier,
+    };
+    return msalObject.getAccount(accountFilter);
   }
 
-  // Tries to refresh the token. Will call [onError] if a token
-  // could not be acquired or if no cached account credentials exist.
-  // Will call [onSuccess] on success and update the global authResult variable.
-  async function refreshToken(onSuccess, onError) {
-    try {
-      // The redirect handler task will complete with auth results if we
-      // were redirected from AAD. If not, it will complete with null
-      // We must wait for it to complete before we allow the login to
-      // attempt to acquire a token silently, and then progress to interactive
-      // login (if silent acquisition fails).
-      let result = await redirectHandlerTask;
-      if (result !== null) {
-        authResult = result;
-      }
-    } catch (error) {
-      authResultError = error;
-      onError(authResultError);
-      return;
-    }
-
-    // Try to sign in silently, assuming we have already signed in and have
-    // a cached access token
-    await silentlyAcquireToken();
-
-    if (authResult != null) {
-      onSuccess(authResult.accessToken ?? null);
-      return;
-    }
+  function getAccounts() {
+    return msalObject.getAllAccounts();
   }
 
-  function getAccount() {
-    // If we have recently authenticated, we use the auth'd account;
-    // otherwise we fallback to using MSAL APIs to find cached auth
-    // accounts in browser storage.
-    if (authResult !== null && authResult.account !== null) {
-      return authResult.account;
-    }
-
-    const currentAccounts = msalObject.getAllAccounts();
-
-    if (currentAccounts === null || currentAccounts.length === 0) {
-      return null;
-    } else if (currentAccounts.length > 1) {
-      // Multiple users - pick the first one, but this shouldn't happen
-      console.warn("Multiple accounts detected, selecting first.");
-
-      return currentAccounts[0];
-    } else if (currentAccounts.length === 1) {
-      return currentAccounts[0];
-    }
-  }
-
-  function logout(onSuccess, onError, showPopup) {
-    const account = getAccount();
+  async function logout(identifier) {
+    const account = getAccount(identifier);
 
     if (!account) {
-      onSuccess();
       return;
     }
 
-    authResult = null;
-    authResultError = null;
-    tokenRequest.scopes = null;
-
-    if (showPopup) {
-      msalObject
-        .logout({account: account})
-        .then((_) => onSuccess())
-        .catch(onError);
-    } else {
-      msalObject
-        .logoutRedirect({
-          account: account,
-          onRedirectNavigate: (url) => {
-            return false;
-          },
-        })
-        .then((_) => onSuccess())
-        .catch(onError);
-    }
-  }
-
-  async function getAccessToken() {
-    var result = await silentlyAcquireToken();
-    return result ? result.accessToken : null;
-  }
-
-  async function getIdToken() {
-    var result = await silentlyAcquireToken();
-    return result ? result.idToken : null;
-  }
-
-  function hasCachedAccountInformation() {
-    return getAccount() != null;
+    await msalObject.logoutRedirect({
+      account: account,
+      onRedirectNavigate: (_) => {
+        return false;
+      },
+    });
   }
 
   return {
     init: init,
-    login: login,
-    refreshToken: refreshToken,
+    acquireToken: acquireToken,
+    acquireTokenSilent: acquireTokenSilent,
+    getAccount: getAccount,
+    getAccounts: getAccounts,
     logout: logout,
-    getIdToken: getIdToken,
-    getAccessToken: getAccessToken,
-    hasCachedAccountInformation: hasCachedAccountInformation,
   };
 })();

--- a/lib/src/core/web/msalconfig.dart
+++ b/lib/src/core/web/msalconfig.dart
@@ -1,0 +1,64 @@
+// This code is adapted from https://github.com/earlybyte/aad_oauth
+// Copyright (c) 2020 Earlybyte GmbH
+// Licensed under the MIT License
+
+@JS()
+
+import 'dart:js_interop';
+
+import '../../models/config/web_config.dart';
+
+/// Interop with JS, we need to convert Config to a JS object or it comes
+/// through as empty when passed to JS.
+///
+/// Parameters according to official Microsoft Documentation:
+/// - Azure AD https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+/// - Azure AD B2C: https://docs.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow
+///
+/// DartDocs of parameters are mostly from those pages.
+extension type JSMsalConfig._(JSObject _) implements JSObject {
+  /// The Application (client) ID that the Azure portal – App registrations experience assigned to your app.
+  external String? clientId;
+
+  /// The tenant value in the path of the request can be used to control who can sign into the application.
+  /// The allowed values are common, organizations, consumers, and tenant identifiers. Or Name of your Azure AD B2C tenant.
+  external String? tenant;
+
+  /// __AAD B2C only__: The user flow to be run. Specify the name of a user flow you've created in your Azure AD B2C tenant.
+  /// For example: b2c_1_sign_in, b2c_1_sign_up, or b2c_1_edit_profile
+  external String? policy;
+
+  /// Using Azure AD B2C instead of standard Azure AD.
+  /// Azure Active Directory B2C provides business-to-customer identity as a service.
+  external bool? isB2C;
+
+  /// The redirect uri of your app, where authentication responses can be sent and received by your app.
+  /// It must exactly match one of the redirect_uris you registered in the portal, except it must be url encoded.
+  /// For native & mobile apps, you should use the default value.
+  external String? redirectUri;
+
+  /// Cache location used when authenticating with a web client.
+  /// "localStorage" - Local browser storage (default)
+  /// "sessionStorage" - Session context
+  /// "memoryStorage" - Memory only
+  external String? cacheLocation;
+
+  /// Azure AD OAuth Configuration. Look at individual fields for description.
+  external JSMsalConfig({
+    String? clientId,
+    String? tenant,
+    String? policy,
+    bool? isB2C,
+    String? redirectUri,
+    String? cacheLocation,
+  });
+
+  factory JSMsalConfig.fromWebConfig(WebConfig config) => JSMsalConfig(
+        clientId: config.clientId,
+        tenant: config.tenant,
+        policy: config.policy,
+        isB2C: config.isB2C,
+        redirectUri: config.redirectUri,
+        cacheLocation: config.cacheLocation.name,
+      );
+}

--- a/lib/src/core/web/web_oauth.dart
+++ b/lib/src/core/web/web_oauth.dart
@@ -78,7 +78,7 @@ class WebOAuth {
     return jsAuthenticationResult.toDart;
   }
 
-  Future<Account> getAccount(String? identifier) async {
+  Future<Account> getAccount([String? identifier]) async {
     return jsGetAccount(identifier?.toJS).toDart;
   }
 
@@ -86,7 +86,7 @@ class WebOAuth {
     return jsGetAccounts().toDart.map((jsAccount) => jsAccount.toDart).toList();
   }
 
-  Future<void> logout(String? identifier) async {
+  Future<void> logout([String? identifier]) async {
     await jsLogout(identifier?.toJS, false.toJS).toDart;
   }
 }

--- a/lib/src/core/web/web_oauth.dart
+++ b/lib/src/core/web/web_oauth.dart
@@ -16,18 +16,18 @@ import 'msalconfig.dart';
 external JSPromise jsInit(JSMsalConfig config);
 
 @JS('acquireToken')
-external JSPromise<JSAuthenticationResult> jsAcquireToken({
+external JSPromise<JSAuthenticationResult> jsAcquireToken(
   JSArray<JSString> scopes,
   JSString prompt,
   JSString? loginHint,
   JSBoolean useRedirect,
-});
+);
 
 @JS('acquireTokenSilent')
-external JSPromise<JSAuthenticationResult> jsAcquireTokenSilent({
+external JSPromise<JSAuthenticationResult> jsAcquireTokenSilent(
   JSArray<JSString> scopes,
   JSString? identifier,
-});
+);
 
 @JS('getAccount')
 external JSAccount jsGetAccount(JSString? identifier);
@@ -59,10 +59,10 @@ class WebOAuth {
     String? loginHint,
   }) async {
     final jsAuthenticationResult = await jsAcquireToken(
-      scopes: scopes.map((scope) => scope.toJS).toList().toJS,
-      prompt: prompt.name.toJS,
-      loginHint: loginHint?.toJS,
-      useRedirect: false.toJS,
+      scopes.map((scope) => scope.toJS).toList().toJS,
+      prompt.name.toJS,
+      loginHint?.toJS,
+      false.toJS,
     ).toDart;
     return jsAuthenticationResult.toDart;
   }
@@ -72,8 +72,8 @@ class WebOAuth {
     String? identifier,
   }) async {
     final jsAuthenticationResult = await jsAcquireTokenSilent(
-      scopes: scopes.map((scope) => scope.toJS).toList().toJS,
-      identifier: identifier?.toJS,
+      scopes.map((scope) => scope.toJS).toList().toJS,
+      identifier?.toJS,
     ).toDart;
     return jsAuthenticationResult.toDart;
   }

--- a/lib/src/core/web/web_oauth.dart
+++ b/lib/src/core/web/web_oauth.dart
@@ -1,0 +1,92 @@
+// This code is adapted from https://github.com/earlybyte/aad_oauth
+// Copyright (c) 2020 Earlybyte GmbH
+// Licensed under the MIT License
+@JS('msalAuth')
+library;
+
+import 'dart:js_interop';
+
+import '../../../msal_auth.dart';
+import '../../models/config/web_config.dart';
+import '../../models/web/js_account.dart';
+import '../../models/web/js_authentication_result.dart';
+import 'msalconfig.dart';
+
+@JS('init')
+external JSPromise jsInit(JSMsalConfig config);
+
+@JS('acquireToken')
+external JSPromise<JSAuthenticationResult> jsAcquireToken({
+  JSArray<JSString> scopes,
+  JSString prompt,
+  JSString? loginHint,
+  JSBoolean useRedirect,
+});
+
+@JS('acquireTokenSilent')
+external JSPromise<JSAuthenticationResult> jsAcquireTokenSilent({
+  JSArray<JSString> scopes,
+  JSString? identifier,
+});
+
+@JS('getAccount')
+external JSAccount jsGetAccount(JSString? identifier);
+
+@JS('getAccounts')
+external JSArray<JSAccount> jsGetAccounts();
+
+@JS('logout')
+external JSPromise jsLogout(
+  JSString? identifier,
+  // ignore: avoid_positional_boolean_parameters
+  JSBoolean showPopup,
+);
+
+class WebOAuth {
+  WebOAuth(this.config);
+
+  final WebConfig config;
+
+  Future<void> init() async {
+    await jsInit(
+      JSMsalConfig.fromWebConfig(config),
+    ).toDart;
+  }
+
+  Future<AuthenticationResult> acquireToken({
+    required List<String> scopes,
+    Prompt prompt = Prompt.whenRequired,
+    String? loginHint,
+  }) async {
+    final jsAuthenticationResult = await jsAcquireToken(
+      scopes: scopes.map((scope) => scope.toJS).toList().toJS,
+      prompt: prompt.name.toJS,
+      loginHint: loginHint?.toJS,
+      useRedirect: false.toJS,
+    ).toDart;
+    return jsAuthenticationResult.toDart;
+  }
+
+  Future<AuthenticationResult> acquireTokenSilent({
+    required List<String> scopes,
+    String? identifier,
+  }) async {
+    final jsAuthenticationResult = await jsAcquireTokenSilent(
+      scopes: scopes.map((scope) => scope.toJS).toList().toJS,
+      identifier: identifier?.toJS,
+    ).toDart;
+    return jsAuthenticationResult.toDart;
+  }
+
+  Future<Account> getAccount(String? identifier) async {
+    return jsGetAccount(identifier?.toJS).toDart;
+  }
+
+  Future<List<Account>> getAccounts() async {
+    return jsGetAccounts().toDart.map((jsAccount) => jsAccount.toDart).toList();
+  }
+
+  Future<void> logout(String? identifier) async {
+    await jsLogout(identifier?.toJS, false.toJS).toDart;
+  }
+}

--- a/lib/src/models/config/cache_location_enum.dart
+++ b/lib/src/models/config/cache_location_enum.dart
@@ -1,0 +1,9 @@
+// This code is adapted from https://github.com/earlybyte/aad_oauth
+// Copyright (c) 2020 Earlybyte GmbH
+// Licensed under the MIT License
+
+enum CacheLocation {
+  localStorage,
+  memoryStorage,
+  sessionStorage;
+}

--- a/lib/src/models/config/web_config.dart
+++ b/lib/src/models/config/web_config.dart
@@ -1,0 +1,67 @@
+// This code is adapted from https://github.com/earlybyte/aad_oauth
+// Copyright (c) 2020 Earlybyte GmbH
+// Licensed under the MIT License
+
+import 'cache_location_enum.dart';
+
+/// Parameters according to official Microsoft Documentation:
+/// - Azure AD https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+/// - Azure AD B2C: https://docs.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow
+///
+/// DartDocs of parameters are mostly from those pages.
+class WebConfig {
+  /// The Application (client) ID that the Azure portal – App registrations experience assigned to your app.
+  final String clientId;
+
+  /// The tenant value in the path of the request can be used to control who can sign into the application.
+  /// The allowed values are common, organizations, consumers, and tenant identifiers. Or Name of your Azure AD B2C tenant.
+  final String tenant;
+
+  /// __AAD B2C only__: The user flow to be run. Specify the name of a user flow you've created in your Azure AD B2C tenant.
+  /// For example: b2c_1_sign_in, b2c_1_sign_up, or b2c_1_edit_profile
+  final String? policy;
+
+  /// Using Azure AD B2C instead of standard Azure AD.
+  /// Azure Active Directory B2C provides business-to-customer identity as a service.
+  final bool isB2C;
+
+  /// The redirect uri of your app, where authentication responses can be sent and received by your app.
+  /// It must exactly match one of the redirect_uris you registered in the portal, except it must be url encoded.
+  /// For native & mobile apps, you should use the default value.
+  final String redirectUri;
+
+  /// Cache location used when authenticating with a web client.
+  /// "CacheLocation.localStorage" - Local browser storage (default)
+  /// "CacheLocation.sessionStorage" - Session context
+  /// "CacheLocation.memoryStorage" - Memory only
+  CacheLocation cacheLocation;
+
+  /// Azure AD OAuth Configuration. Look at individual fields for description.
+  WebConfig({
+    required this.tenant,
+    required this.clientId,
+    required this.redirectUri,
+    this.policy,
+    this.isB2C = false,
+    this.cacheLocation = CacheLocation.localStorage,
+  });
+
+  WebConfig copyWith({
+    String? tenant,
+    String? clientId,
+    String? redirectUri,
+    String? policy,
+    bool? isB2C,
+    CacheLocation? cacheLocation,
+    Map<String, String>? customParameters,
+  }) {
+    return WebConfig(
+      tenant: tenant ?? this.tenant,
+      clientId: clientId ?? this.clientId,
+      redirectUri: redirectUri ?? this.redirectUri,
+      policy: policy ?? this.policy,
+      isB2C: isB2C ?? this.isB2C,
+      cacheLocation: cacheLocation ?? this.cacheLocation,
+    );
+  }
+}

--- a/lib/src/models/exception/msal_argument_exception.dart
+++ b/lib/src/models/exception/msal_argument_exception.dart
@@ -9,7 +9,7 @@ class MsalArgumentException extends MsalException {
   /// Detailed error code.
   final String errorCode;
 
-  /// Argument name that has thown this exception.
+  /// Argument name that has thrown this exception.
   final String argumentName;
 
   /// Operation name provided by SDK.

--- a/lib/src/models/web/js_account.dart
+++ b/lib/src/models/web/js_account.dart
@@ -1,0 +1,17 @@
+@JS()
+
+import 'dart:js_interop';
+
+import '../../../msal_auth.dart';
+
+extension type JSAccount._(JSObject _) implements JSObject {
+  external JSString homeAccountId;
+  external JSString username;
+  external JSString name;
+
+  Account get toDart => Account(
+        id: homeAccountId.toDart,
+        username: username.toDart,
+        name: name.toDart,
+      );
+}

--- a/lib/src/models/web/js_authentication_result.dart
+++ b/lib/src/models/web/js_authentication_result.dart
@@ -1,0 +1,33 @@
+@JS()
+
+import 'dart:js_interop';
+
+import '../../../msal_auth.dart';
+import 'js_account.dart';
+
+extension type JSAuthenticationResult._(JSObject _) implements JSObject {
+  external JSString accessToken;
+  external JSString expiresOn;
+  external JSString idToken;
+  external JSString authority;
+  external JSString tenantId;
+  external JSArray<JSString> scopes;
+  external JSString correlationId;
+  external JSAccount account;
+
+  AuthenticationResult get toDart => AuthenticationResult(
+        accessToken: accessToken.toDart,
+        authenticationScheme: '',
+        expiresOn: DateTime.parse(expiresOn.toDart),
+        idToken: idToken.toDart,
+        authority: authority.toDart,
+        tenantId: tenantId.toDart,
+        scopes: scopes.toDart.map((scope) => scope.toDart).toList(),
+        correlationId: correlationId.toDart,
+        account: Account(
+          id: account.homeAccountId.toDart,
+          username: account.username.toDart,
+          name: account.name.toDart,
+        ),
+      );
+}


### PR DESCRIPTION
This PR adds methods and classes to interoperate with the MSAL JavaScript SDK. 

A future PR will implement the methods for `WebPublicClientApplication`, `WebSingleAccountPca` and `WebMultipleAccountPca`.

Depends on #58. Please merge that one first to see the correct diffs here.