### PR TITLE
Set name as nullable

### DIFF
--- a/example/lib/widgets/account_card.dart
+++ b/example/lib/widgets/account_card.dart
@@ -28,7 +28,7 @@ class AccountCard extends StatelessWidget {
               ),
               ListTile(
                 title: Text('Name'),
-                subtitle: Text(account.name),
+                subtitle: Text(account.name ?? 'N/A'),
               ),
             ],
           ),

--- a/lib/src/models/result/account.dart
+++ b/lib/src/models/result/account.dart
@@ -9,7 +9,7 @@ final class Account {
   final String? username;
 
   /// Name received from account claims.
-  final String name;
+  final String? name;
 
   Account({
     required this.id,

--- a/lib/src/models/result/account.dart
+++ b/lib/src/models/result/account.dart
@@ -9,6 +9,7 @@ final class Account {
   final String? username;
 
   /// Name received from account claims.
+  /// It may be null if the user is registered without setting a name.
   final String? name;
 
   Account({


### PR DESCRIPTION
This allows microsoft account with no name set to be able to login through the. msal_auth library