### PR TITLE
Remove Final Keyword from Single & Multi AccountPCA classes

### DIFF
--- a/lib/src/core/multiple_account_pca.dart
+++ b/lib/src/core/multiple_account_pca.dart
@@ -2,7 +2,7 @@ part of 'public_client_application.dart';
 
 /// This class is used to create public client application for multiple account
 /// mode.
-final class MultipleAccountPca extends PublicClientApplication {
+class MultipleAccountPca extends PublicClientApplication {
   MultipleAccountPca._create();
 
   /// Creates multiple account public client application.

--- a/lib/src/core/single_account_pca.dart
+++ b/lib/src/core/single_account_pca.dart
@@ -2,7 +2,7 @@ part of 'public_client_application.dart';
 
 /// This class is used to create public client application for single account
 /// mode.
-final class SingleAccountPca extends PublicClientApplication {
+class SingleAccountPca extends PublicClientApplication {
   SingleAccountPca._create();
 
   /// Creates single account public client application.


### PR DESCRIPTION
- Removing the final keyword we can extend that class to different purposes like Mock, etc