### PR TITLE
Fix UIViewController.keyViewController not ready

### DIFF
--- a/ios/Classes/MsalAuthPlugin.swift
+++ b/ios/Classes/MsalAuthPlugin.swift
@@ -184,6 +184,7 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
         }
 
         guard let viewController = UIViewController.keyViewController else {
+            setUiNotReadyError(result: result)
             return
         }
         let webViewParameters = MSALWebviewParameters(
@@ -488,6 +489,16 @@ extension MsalAuthPlugin {
                 code: "INTERNAL_ERROR",
                 message: "There is no currently signed in account.",
                 details: "no_account"))
+    }
+
+    /// Sets ui not ready error to result.
+    /// - Parameter result: Result of the method call.
+    fileprivate func setUiNotReadyError(result: @escaping FlutterResult) {
+        result(
+            FlutterError(
+                code: "UI_NOT_READY_ERROR",
+                message: "The UI is not ready. UIViewController.keyViewController",
+                details: "UI not ready!"))
     }
 
     /// Common MSAL error handling function that returns error to Dart.


### PR DESCRIPTION
On iOS devices, sometimes I run into the issue where the `UIViewController.keyViewController` is not ready to show the login.  This happens even when using a `WidgetsBinding.instance.addPostFrameCallback` inside of my `initState` function. 

The exceptions from the iOS Swift code were not making it back to Dart/Flutter. This PR adds a `setUiNotReadyError` function that handles this error and sends the result back to Dart/Flutter so that the exception can be handled.

Let me know what you think.