### PR TITLE
Set `brokerAvailability` in MSAL config before creating PCA in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Follow the [Android MSAL Authority] documentation to configure it in various way
   </array>
   ```
 
-- Add `LSApplicationQueriesSchemes` to allow making call to [Microsoft Authenticator] app if installed.
+- Add `LSApplicationQueriesSchemes` to use the [Microsoft Authenticator] app as a broker for authentication. Not required when `Safari Browser` or `WebView` is used as a broker.
 
   ```plist
   <key>LSApplicationQueriesSchemes</key>
@@ -203,6 +203,8 @@ Follow the [Android MSAL Authority] documentation to configure it in various way
 	  <string>msauthv3</string>
   </array>
   ```
+
+  - If you use `Broker.msAuthenticator` after declaring the above schemes but the Authenticator app is not installed on the iPhone, the authentication will fall back to using `Safari Browser`.
 
 ---
 

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -71,10 +71,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/MsalAuthPlugin.swift
+++ b/ios/Classes/MsalAuthPlugin.swift
@@ -118,6 +118,15 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
         authorityType: String,
         result: @escaping FlutterResult
     ) {
+        // Sets broker availability. this is required to avoid error on PCA creation
+        // when 'LSApplicationQueriesSchemes' is not defined in 'Info.plist'.
+        switch MsalAuth.broker {
+        case "webView", "safariBrowser":
+            MSALGlobalConfig.brokerAvailability = .none
+        default:
+            break
+        }
+        
         var pcaConfig: MSALPublicClientApplicationConfig!
 
         if authority != nil {
@@ -195,10 +204,8 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
             switch MsalAuth.broker {
             case "webView":
                 webViewParameters.webviewType = .wkWebView
-                MSALGlobalConfig.brokerAvailability = .none
             case "safariBrowser":
                 webViewParameters.webviewType = .safariViewController
-                MSALGlobalConfig.brokerAvailability = .none
             default:
                 webViewParameters.webviewType = .default
             }


### PR DESCRIPTION
This is a small edge case when a dev does not declare the `LSApplicationQueriesSchemes` in `Info.plist`. This is actually not required when an app does not want to authenticate using the Microsoft Authenticator app. So a fix is to set `MSALGlobalConfig.brokerAvailability = .none` before creating a public client app. The broker should be `Safari Browser` or `WebView` in this case.

Official document: https://learn.microsoft.com/en-us/entra/msal/objc/install-and-configure-msal?source=recommendations#ios-only-steps