### PR TITLE
Add assert in acquireTokenSilent: Identifier can not be null for multiple account mode

### DIFF
--- a/lib/src/core/public_client_application.dart
+++ b/lib/src/core/public_client_application.dart
@@ -58,6 +58,10 @@ class PublicClientApplication {
     String? identifier,
   }) async {
     assert(scopes.isNotEmpty, 'Scopes can not be empty');
+    assert(
+      this is MultipleAccountPca && identifier == null,
+      'Identifier can not be null for multiple account mode',
+    );
     final arguments = <String, dynamic>{
       'scopes': scopes,
       'identifier': identifier,


### PR DESCRIPTION
`acquireTokenSilent` method accepts a nullable identifier because this method can be called from a single or multiple account PCA. When PCA is made using single account mode, there is no need for an identifier, as the single account is there, and so account details can be fetched from the cache directly. But when PCA is made using multiple accounts, an identifier is required to fetch the particular account details. So, for now, as per the code structure, adding `asserts` check is the fix.