### PR TITLE
Android Setup & Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,21 @@ To implement `MSAL` in Flutter, you first need to set up an app in the `Azure Po
 
 ### Android Setup - Azure portal
 
-- For Android, You need to provide `package name` and release `signature hash`.
-  - To generate a signature hash in Flutter, use the below command:
-  
-    ```Bash
-    keytool -exportcert -alias androidreleasekey -keystore app/upload-keystore.jks | openssl sha1 -binary | openssl base64
-    ```
+For Android, You need to provide `package name` and `signature hash`. To generate a signature hash in Flutter, use the below command from your project's `android` folder:
 
-  - Make sure you have release `keystore` file placed inside `/app` folder.
-  - Only one signature hash is required because it maps with `AndroidManifest.xml`.
+- Debug:
+  ```Bash
+  keytool -exportcert -alias androiddebugkey -keystore ~/.android/debug.keystore -storepass android -keypass android | openssl sha1 -binary | openssl base64
+  ```
+
+- Release:
+  ```Bash
+  keytool -exportcert -alias upload -keystore app/upload-keystore.jks | openssl sha1 -binary | openssl base64
+  ```
+
+  - Ensure you have `upload-keystore.jks` file placed inside `android/app` folder. Follow the Flutter's documentation [Build and release an Android app] to create a release setup.
+
+Register both signature hash in Azure's Android Platform configurations.
 
 ---
   
@@ -140,33 +146,51 @@ Follow the [Android MSAL Authority] documentation to configure it in various way
 
 ---
 
+### Add Internet and Network State permission in AndroidManifest.xml
+
+This permission declaration is required for browser-delegated authentication:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+
+---
+
 ### Add BrowserTabActivity in AndroidManifest.xml
 
-- If you use `Browser` for authentication, you must specify `BrowserTabActivity` within the `<application>` tag in your **AndroidManifest.xml** file.
+If you use `Browser` or `Authenticator` app for authentication, you must specify `BrowserTabActivity` within the `<application>` tag in your **AndroidManifest.xml** file.
 
-  ```XML
-  <application>
-  ...
+```XML
+<application>
+...
 
-    <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
+  <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
 
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
 
-            <data
-                android:host="com.example.msal_auth_example"
-                android:path="/<BASE64_ENCODED_PACKAGE_SIGNATURE>"
-                android:scheme="msauth" />
-        </intent-filter>
-    </activity>
+          <data
+              android:host="com.example.msal_auth_example"
+              android:path="/<BASE64_ENCODED_PACKAGE_SIGNATURE>"
+              android:scheme="msauth" />
+      </intent-filter>
+  </activity>
     
-  </application>
-  ```
+</application>
+```
 - Replace `host` with your app's package name and `path` with the `base64 signature hash` that was generated earlier.
+- To load debug and release signature hash programmatically in your project, follow the [`example README`] and [`example`] code.
 
 > To learn more about configuring JSON, follow [Android MSAL configuration].
+
+### ProGuard
+
+You don't need to include any rules for `MSAL Android` library as this is done using [`consumer-rules.pro`] file within this Flutter plugin.
+
+> For more info regarding ProGuard, follow [Android App Optimization].
 
 ## iOS Configuration
 
@@ -361,22 +385,12 @@ You can learn more about [MSAL exceptions - Android] and [MSAL exceptions - iOS/
 
 The [`example`] app demonstrates all the features supported by this plugin with providing a practical implementation.
 
-It uses environment variables for the values such as client id, redirect URI, etc to make it easier to configure the app for different environments.
-
-To set it up, create a `.env/development.env` file in the root of your project and add your values like this:
-
-```ini
-AAD_CLIENT_ID=your-apps-client-id
-AAD_ANDROID_REDIRECT_URI=your-android-apps-redirect-uri
-AAD_APPLE_AUTHORITY=https://login.microsoftonline.com/common
-```
-
-Use B2C authority URL in `AAD_APPLE_AUTHORITY` if your app uses `b2c` flow.
-
-Follow [`example`] code for more details on implementation.
+See the [`example README`] for detailed setup instructions.
 
 
 [Azure Portal]: https://portal.azure.com/
+[Build and release an Android app]: https://docs.flutter.dev/deployment/android
+[Android App Optimization]: https://developer.android.com/topic/performance/app-optimization/enable-app-optimization
 [Microsoft default configuration file]: https://learn.microsoft.com/en-in/entra/identity-platform/msal-configuration#the-default-msal-configuration-file
 [Microsoft Authenticator App]: https://play.google.com/store/apps/details?id=com.azure.authenticator
 [Android MSAL configuration]: https://learn.microsoft.com/en-in/entra/identity-platform/msal-configuration
@@ -387,5 +401,7 @@ Follow [`example`] code for more details on implementation.
 [MSAL exceptions - Android]: https://learn.microsoft.com/en-us/entra/identity-platform/msal-android-handling-exceptions
 [MSAL exceptions - iOS/macOS]: https://learn.microsoft.com/en-us/entra/msal/objc/error-handling-ios
 [`example`]: example
+[`example README`]: example/README.md
+[`consumer-rules.pro`]: android/consumer-rules.pro
 [`AppDelegate.swift`]: example/ios/Runner/AppDelegate.swift
 [`DebugProfile.entitlements`]: example/macos/Runner/DebugProfile.entitlements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        consumerProguardFiles("consumer-rules.pro")
     }
 }
 

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,31 @@
+# Required rules for MSAL
+-dontwarn com.google.auto.value.AutoValue
+
+-dontwarn com.google.crypto.tink.subtle.Ed25519Sign$KeyPair
+-dontwarn com.google.crypto.tink.subtle.Ed25519Sign
+-dontwarn com.google.crypto.tink.subtle.Ed25519Verify
+-dontwarn com.google.crypto.tink.subtle.X25519
+-dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
+
+-dontwarn edu.umd.cs.findbugs.annotations.NonNull
+-dontwarn edu.umd.cs.findbugs.annotations.Nullable
+-dontwarn edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+
+-dontwarn org.bouncycastle.asn1.ASN1Encodable
+-dontwarn org.bouncycastle.asn1.pkcs.PrivateKeyInfo
+-dontwarn org.bouncycastle.asn1.x509.AlgorithmIdentifier
+-dontwarn org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+-dontwarn org.bouncycastle.cert.X509CertificateHolder
+-dontwarn org.bouncycastle.cert.jcajce.JcaX509CertificateHolder
+-dontwarn org.bouncycastle.crypto.BlockCipher
+-dontwarn org.bouncycastle.crypto.CipherParameters
+-dontwarn org.bouncycastle.crypto.InvalidCipherTextException
+-dontwarn org.bouncycastle.crypto.engines.AESEngine
+-dontwarn org.bouncycastle.crypto.modes.GCMBlockCipher
+-dontwarn org.bouncycastle.crypto.params.AEADParameters
+-dontwarn org.bouncycastle.crypto.params.KeyParameter
+-dontwarn org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+-dontwarn org.bouncycastle.jce.provider.BouncyCastleProvider
+-dontwarn org.bouncycastle.openssl.PEMKeyPair
+-dontwarn org.bouncycastle.openssl.PEMParser
+-dontwarn org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter

--- a/example/README.md
+++ b/example/README.md
@@ -1,5 +1,163 @@
-# msal_auth
+# MSAL Example App
 
-## Getting Started
+A comprehensive Flutter example app demonstrating Microsoft Authentication Library (MSAL) integration with all supported features.
 
-Follow the Microsoft MSAL documentation for more details.
+Before running the app, ensure you follow the steps below to configure the example app.
+
+## Environment Configuration
+
+The example app uses environment variables for values such as client ID, redirect URI, etc., to make it easier to configure the app for different environments.
+
+### Create Environment File
+
+Create a .env/development.env file in the [example] folder with your Azure app credentials:
+
+```ini
+AAD_CLIENT_ID=your-apps-client-id
+AAD_APPLE_AUTHORITY=https://login.microsoftonline.com/common
+```
+
+Use B2C authority URL in `AAD_APPLE_AUTHORITY` if your app uses `b2c` flow.
+
+## Platform-Specific Setup
+
+### Android Configuration
+
+#### 1. Update MSAL Configuration
+
+The example uses [msal_config.json] for Android configuration. Update the fields according to your requirements.
+
+To learn more about configuring JSON, follow [Android MSAL configuration].
+
+#### 2. Generate Keystore
+
+This is required for **release** builds only. Skip this step if you don't want to run/build in release mode.
+
+Follow the Flutter's documentation on [Build and release an Android app].
+
+For this example app, you only need to place the upload-keystore.jks in the [android/app] folder and set the path in `storeFile` within `key.properties`:
+
+```properties
+storeFile=./upload-keystore.jks
+```
+
+#### 2. Generate Signature Hash
+
+This is required to set up the Android redirect URL. Debug and release modes will have different signature hashes.
+
+Generate the debug signature hash only if you plan to test the app in debug mode only.
+
+From example's [`android`] folder, run the below command:
+- Debug
+
+  ```Bash
+  keytool -exportcert -alias androiddebugkey -keystore ~/.android/debug.keystore -storepass android -keypass android | openssl sha1 -binary | openssl base64
+  ```
+
+- Release (ensure you have generated the keystore)
+
+  ```Bash
+  keytool -exportcert -alias upload -keystore app/upload-keystore.jks | openssl sha1 -binary | openssl base64
+  ```
+
+Register the signature hash above in the Android platform configurations in [Azure Portal] and obtain the Redirect URI. Add that value in relevant keys in `.env/development.env`:
+
+```ini
+AAD_DEBUG_ANDROID_REDIRECT_URI=debug-redirect-uri
+# Required only if you want to run the app in release mode
+AAD_RELEASE_ANDROID_REDIRECT_URI=release-redirect-uri
+```
+
+If release mode is not required, remove the conditional logic and use debug redirect URI directly in [msal_auth_service.dart]:
+
+```Dart
+AndroidConfig(
+  redirectUri: Environment.aadDebugAndroidRedirectUri,
+)
+```
+
+#### 3. Create `secret.properties`
+
+This is required only if you want to use `Browser` or the `Authenticator` app for authorization. This step passes the signature hash value to the [`AndroidManifest.xml`] with the help of [`app/build.gradle.kts`].
+
+Create `android/secret.properties` file for storing signature hash values:
+
+```ini
+MSAL_DEBUG_SIGNATURE_HASH=debug-signature-hash
+# Required only if you want to run the app in release mode
+MSAL_RELEASE_SIGNATURE_HASH=release-signature-hash
+```
+
+If you only want to use `WebView` for authentication, the following changes are required:
+
+- Following changes in [`msal_config.json`]:
+
+  ```json
+  "authorization_user_agent": "WEBVIEW",
+  "broker_redirect_uri_registered": false
+  ```
+
+- Remove the below signature hash declaration from [`app/build.gradle.kts`]:
+
+  ```Kotlin
+  val secretProperties = Properties()
+  val secretPropertiesFile = rootProject.file("secret.properties")
+  if (secretPropertiesFile.exists()) {
+      secretProperties.load(FileInputStream(secretPropertiesFile))
+  }
+
+  val msalDebugSignatureHash = secretProperties["MSAL_DEBUG_SIGNATURE_HASH"]
+  val msalReleaseSignatureHash = secretProperties["MSAL_RELEASE_SIGNATURE_HASH"]
+
+  debug {
+    manifestPlaceholders["msalSignatureHash"] = msalDebugSignatureHash as String
+  }
+
+  release {
+    manifestPlaceholders["msalSignatureHash"] = msalReleaseSignatureHash as String
+  }
+  ```
+
+- Remove the below block from [`AndroidManifest.xml`]:
+
+  ```xml
+  <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+  ...
+  </activity>
+  ```
+
+## Running the Example
+
+Run configurations are created for IDEs to execute the build workflow. From the terminal, you can use the commands below from the [`example`] directory:
+
+### Commands
+
+#### Run the app in debug mode
+
+```sh
+flutter run --dart-define-from-file=.env/development.env
+```
+
+#### Run the app in release mode
+
+```sh
+flutter run --release --dart-define-from-file=.env/development.env
+```
+
+#### Build APK
+
+```sh
+flutter build apk --dart-define-from-file=.env/development.env
+```
+
+
+[Azure Portal]: https://portal.azure.com/
+[`example`]: ./
+[`msal_config.json`]: assets/msal_config.json
+[Android MSAL configuration]: https://learn.microsoft.com/en-in/entra/identity-platform/msal-configuration
+[`android`]: android
+[`android/app`]: android/app
+[`msal_auth_service.dart`]: lib/core/msal_auth_service.dart
+[Build and release an Android app]: https://docs.flutter.dev/deployment/android
+[`AndroidManifest.xml`]: android/app/src/main/AndroidManifest.xml
+[`app/build.gradle.kts`]: android/app/build.gradle.kts

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -9,5 +9,6 @@ GeneratedPluginRegistrant.java
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
 key.properties
+secret.properties
 **/*.keystore
 **/*.jks

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -33,6 +33,10 @@ android {
         release {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt")
+            )
         }
     }
 }

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,9 +1,27 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+}
+
+val secretProperties = Properties()
+val secretPropertiesFile = rootProject.file("secret.properties")
+if (secretPropertiesFile.exists()) {
+    secretProperties.load(FileInputStream(secretPropertiesFile))
+}
+
+val msalDebugSignatureHash = secretProperties["MSAL_DEBUG_SIGNATURE_HASH"]
+val msalReleaseSignatureHash = secretProperties["MSAL_RELEASE_SIGNATURE_HASH"]
 
 android {
     namespace = "com.example.msal_auth_example"
@@ -29,10 +47,23 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
+
     buildTypes {
+        debug {
+            manifestPlaceholders["msalSignatureHash"] = msalDebugSignatureHash as String
+        }
+
         release {
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            manifestPlaceholders["msalSignatureHash"] = msalReleaseSignatureHash as String
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt")

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
 
                 <data
                     android:host="com.example.msal_auth_example"
-                    android:path="/d6fGnqW06DVdPPe3zG12HTV2QkI="
+                    android:path="/${msalSignatureHash}"
                     android:scheme="msauth" />
             </intent-filter>
         </activity>

--- a/example/lib/core/msal_auth_service.dart
+++ b/example/lib/core/msal_auth_service.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 
+import 'package:flutter/foundation.dart';
 import 'package:msal_auth/msal_auth.dart';
 
 import '../environment.dart';
@@ -35,7 +36,9 @@ final class MsalAuthService {
   }) async {
     final androidConfig = AndroidConfig(
       configFilePath: 'assets/msal_config.json',
-      redirectUri: Environment.aadAndroidRedirectUri,
+      redirectUri: kDebugMode
+          ? Environment.aadDebugAndroidRedirectUri
+          : Environment.aadReleaseAndroidRedirectUri,
     );
 
     final appleConfig = AppleConfig(

--- a/example/lib/environment.dart
+++ b/example/lib/environment.dart
@@ -3,7 +3,9 @@ final class Environment {
   Environment._();
 
   static const aadClientId = String.fromEnvironment('AAD_CLIENT_ID');
-  static const aadAndroidRedirectUri =
-      String.fromEnvironment('AAD_ANDROID_REDIRECT_URI');
+  static const aadDebugAndroidRedirectUri =
+      String.fromEnvironment('AAD_DEBUG_ANDROID_REDIRECT_URI');
+  static const aadReleaseAndroidRedirectUri =
+      String.fromEnvironment('AAD_RELEASE_ANDROID_REDIRECT_URI');
   static const aadIosAuthority = String.fromEnvironment('AAD_APPLE_AUTHORITY');
 }


### PR DESCRIPTION
## Android Setup

### Example App
- Set up signature hash in `AndroidManifest.xml` programatically using `manifestPlaceholders`
- Added Internet and Network state permissions in `AndroidManifest.xml`. This is not a compulsory requirement, as declared in the native Android MSAL library. Therefore, when the Android app builds, it merges all the manifests. I think adding this permission explicitly is recommended.

### ProGuard
- Added `consumer-rules.pro` in `android` folder to keep required files from `MSAL Android` in a release mode

## README Update
- Updated the Android setup section with documentation of permissions, generating a signature hash, and ProGuard
- Updated the `example/README` for detailed instructions on how to set up the example app.