### PR TITLE
Remove call of acquireTokenSilent from acquireToken method

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -147,36 +147,16 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
             return
         }
 
-        if (msal.iSingleAccountPca != null) {
-            msal.iSingleAccountPca!!.currentAccount?.let { accountResult ->
-                if (accountResult.currentAccount != null) {
-                    acquireTokenSilent(scopes, null, result)
-                } else {
-                    msal.activity.let {
-                        val builder = AcquireTokenParameters.Builder()
-                        builder.startAuthorizationFromActivity(it)
-                            .withScopes(scopes.toList())
-                            .withPrompt(prompt)
-                            .withLoginHint(loginHint)
-                            .withCallback(msal.authenticationCallback(result))
+        msal.activity.let {
+            val builder = AcquireTokenParameters.Builder()
+            builder.startAuthorizationFromActivity(it)
+                .withScopes(scopes.toList())
+                .withPrompt(prompt)
+                .withLoginHint(loginHint)
+                .withCallback(msal.authenticationCallback(result))
 
-                        val acquireTokenParameters = builder.build()
-                        msal.iPublicClientApplication.acquireToken(acquireTokenParameters)
-                    }
-                }
-            }
-        } else if (msal.iMultipleAccountPca != null) {
-            msal.activity.let {
-                val builder = AcquireTokenParameters.Builder()
-                builder.startAuthorizationFromActivity(it)
-                    .withScopes(scopes.toList())
-                    .withPrompt(prompt)
-                    .withLoginHint(loginHint)
-                    .withCallback(msal.authenticationCallback(result))
-
-                val acquireTokenParameters = builder.build()
-                msal.iPublicClientApplication.acquireToken(acquireTokenParameters)
-            }
+            val acquireTokenParameters = builder.build()
+            msal.iPublicClientApplication.acquireToken(acquireTokenParameters)
         }
     }
 

--- a/ios/Classes/MsalAuthPlugin.swift
+++ b/ios/Classes/MsalAuthPlugin.swift
@@ -215,22 +215,7 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
         tokenParams.promptType = promptType
         tokenParams.loginHint = loginHint
-
-        var account: MSALAccount?
-
-        // Call current account for single account mode. multiple account mode needs to give account identifier to get particular account.
-        if MsalAuth.pcaType == PublicClientApplicationType.single {
-            if let currentAccount = getCurrentAccount() {
-                account = currentAccount
-            }
-        }
-
-        if account != nil {
-            acquireTokenSilent(
-                scopes: scopes, identifier: account?.identifier, result: result)
-            return
-        }
-
+        
         pca.acquireToken(
             with: tokenParams,
             completionBlock: { (msalresult, error) in

--- a/macos/Classes/MsalAuthPlugin.swift
+++ b/macos/Classes/MsalAuthPlugin.swift
@@ -195,21 +195,6 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
         tokenParams.promptType = promptType
         tokenParams.loginHint = loginHint
 
-        var account: MSALAccount?
-
-        // Call current account for single account mode. multiple account mode needs to give account identifier to get particular account.
-        if MsalAuth.pcaType == PublicClientApplicationType.single {
-            if let currentAccount = getCurrentAccount() {
-                account = currentAccount
-            }
-        }
-
-        if account != nil {
-            acquireTokenSilent(
-                scopes: scopes, identifier: account?.identifier, result: result)
-            return
-        }
-
         pca.acquireToken(
             with: tokenParams,
             completionBlock: { (msalresult, error) in


### PR DESCRIPTION
This `MsalUiRequiredException` issue is caused by the internal call of the `acquireTokenSilent` method within the `acquireToken` method in native calls. Consider a signed-in user with an expired auth token;

1. The app will call acquireTokenSilent to get a new auth token silently.
2. If the refresh token is valid, there will be no issue as the above method will give a valid auth token. But if the refresh token is also expired, the above method will throw a Ui required exception, and so your app will call acquireToken to authenticate the user interactively.
3. The acquireToken method will check for an existing account from the cache, and it will be found. Then, the acquireTokenSilent method will be called with specifying this account. Again, UiRequiredException and this will be thrown inside the acquireToken method's catch, and execution will stop.