### PR TITLE
Add authority parameter support for acquireToken and acquireTokenSilent methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,10 @@ final authResult = await publicClientApplication.acquireToken(
   // UI option for authentication, default is [Prompt.whenRequired]
   prompt: Prompt.login,
   // Provide 'loginHint' if you have.
-  loginHint: '<Email Id / Username / Unique Identifier>'
+  loginHint: '<Email Id / Username / Unique Identifier>',
+  // Optional: Custom authority URL for B2C or different
+  // tenant scenarios
+  authority: '<Authority URL>',
 );
 
 log('Auth result: ${authResult.toJson()}');
@@ -349,6 +352,10 @@ if (expiresOn.isBefore(DateTime.now())) {
   final authResult = await publicClientApplication.acquireTokenSilent(
     scopes: <String>[], // List of string same as "acquireToken()"
     identifier: 'Account Identifier, required for multiple account mode',
+    // Authority URL where you want to refresh tokens using
+    // a different policy than the original authentication.
+    // Required for B2C scenarios.
+    authority: '<Authority URL>',
   );
 
   log('Auth result: ${authResult.toJson()}');

--- a/example/lib/core/msal_auth_service.dart
+++ b/example/lib/core/msal_auth_service.dart
@@ -76,12 +76,14 @@ final class MsalAuthService {
   Future<(AuthenticationResult?, MsalException?)> acquireToken({
     String? loginHint,
     Prompt prompt = Prompt.whenRequired,
+    String? authority,
   }) async {
     try {
       final result = await publicClientApplication?.acquireToken(
         scopes: scopes,
         loginHint: loginHint,
         prompt: prompt,
+        authority: authority,
       );
       log('Acquire token => ${result?.toJson()}');
       return (result, null);
@@ -94,11 +96,13 @@ final class MsalAuthService {
   /// Common method for both account mode.
   Future<(AuthenticationResult?, MsalException?)> acquireTokenSilent({
     String? identifier,
+    String? authority,
   }) async {
     try {
       final result = await publicClientApplication?.acquireTokenSilent(
         scopes: scopes,
         identifier: identifier,
+        authority: authority,
       );
       log('Acquire token silent => ${result?.toJson()}');
       return (result, null);
@@ -107,7 +111,7 @@ final class MsalAuthService {
 
       // If it is a UI required exception, try to acquire token interactively.
       if (e is MsalUiRequiredException) {
-        return acquireToken();
+        return acquireToken(authority: authority);
       }
       return (null, e);
     }

--- a/ios/Classes/MsalAuth.swift
+++ b/ios/Classes/MsalAuth.swift
@@ -4,6 +4,7 @@ import MSAL
 /// Singleton class that manages required objects for [MsalAuthPlugin].
 class MsalAuth {
     static var pcaType : PublicClientApplicationType!
+    static var authorityType : AuthorityType!
     static var publicClientApplication : MSALPublicClientApplication!
     static var broker : String!
 }
@@ -12,4 +13,10 @@ class MsalAuth {
 enum PublicClientApplicationType {
     case single
     case multiple
+}
+
+/// Authority type.
+enum AuthorityType {
+    case aad
+    case b2c
 }

--- a/ios/Classes/MsalAuthPlugin.swift
+++ b/ios/Classes/MsalAuthPlugin.swift
@@ -29,13 +29,19 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
                 }(),
                 let clientId = dict["clientId"] as? String,
                 let broker = dict["broker"] as? String,
-                let authorityType = dict["authorityType"] as? String
+                let authorityType: AuthorityType = {
+                    switch call.method {
+                    case "b2c": return .b2c
+                    default: return .aad
+                    }
+                }()
             else {
                 setInternalError(methodName: call.method, result: result)
                 return
             }
 
             MsalAuth.broker = broker
+            MsalAuth.authorityType = authorityType
             let authority = dict["authority"] as? String
 
             createPublicClientApplication(
@@ -63,9 +69,10 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
             }
 
             let loginHint = dict["loginHint"] as? String
+            let authority = dict["authority"] as? String
 
             acquireToken(
-                scopes: scopes, promptType: promptType, loginHint: loginHint,
+                scopes: scopes, promptType: promptType, loginHint: loginHint, authority: authority,
                 result: result)
         case "acquireTokenSilent":
             guard let dict = call.arguments as? NSDictionary,
@@ -76,9 +83,10 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
             }
 
             let identifier = dict["identifier"] as? String
+            let authority = dict["authority"] as? String
 
             acquireTokenSilent(
-                scopes: scopes, identifier: identifier, result: result)
+                scopes: scopes, identifier: identifier, authority: authority, result: result)
 
         case "currentAccount": getCurrentAccount(result: result)
 
@@ -115,7 +123,7 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
     private func createPublicClientApplication(
         pcaType: PublicClientApplicationType,
         clientId: String, authority: String?,
-        authorityType: String,
+        authorityType: AuthorityType,
         result: @escaping FlutterResult
     ) {
         // Sets broker availability. this is required to avoid error on PCA creation
@@ -141,7 +149,7 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
             do {
                 switch authorityType {
-                case "b2c":
+                case .b2c:
                     let b2cAuthority = try MSALB2CAuthority(url: authorityUrl)
                     pcaConfig = MSALPublicClientApplicationConfig(
                         clientId: clientId, redirectUri: nil,
@@ -182,9 +190,10 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
     ///   - scopes: Scopes to be requested.
     ///   - promptType: Prompt type.
     ///   - loginHint: Login hint.
+    ///   - authority: Authority URL to override default authority.
     ///   - result: Result of the method call.
     private func acquireToken(
-        scopes: [String], promptType: MSALPromptType, loginHint: String?,
+        scopes: [String], promptType: MSALPromptType, loginHint: String?, authority: String?,
         result: @escaping FlutterResult
     ) {
         guard let pca = MsalAuth.publicClientApplication else {
@@ -221,6 +230,16 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
         tokenParams.promptType = promptType
         tokenParams.loginHint = loginHint
         
+        if let authority = authority {
+            do {
+                let msalAuthority = try getMsalAuthority(authority: authority)
+                tokenParams.authority = msalAuthority
+            } catch let error as NSError {
+                setMsalError(error: error, result: result)
+                return
+            }
+        }
+        
         pca.acquireToken(
             with: tokenParams,
             completionBlock: { (msalresult, error) in
@@ -241,9 +260,10 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
     /// - Parameters:
     ///   - scopes: Scopes to be requested.
     ///   - identifier: Account identifier.
+    ///   - authority: Authority URL to override cached account's authority.
     ///   - result: Result of the method call.
     private func acquireTokenSilent(
-        scopes: [String], identifier: String? = nil,
+        scopes: [String], identifier: String? = nil, authority: String?,
         result: @escaping FlutterResult
     ) {
         guard let pca = MsalAuth.publicClientApplication else {
@@ -266,6 +286,16 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
         let silentParams = MSALSilentTokenParameters(
             scopes: scopes, account: account)
+        
+        if let authority = authority {
+            do {
+                let msalAuthority = try getMsalAuthority(authority: authority)
+                silentParams.authority = msalAuthority
+            } catch let error as NSError {
+                setMsalError(error: error, result: result)
+                return
+            }
+        }
 
         pca.acquireTokenSilent(
             with: silentParams,
@@ -411,6 +441,18 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
 // MARK: - MsalAuthPlugin
 extension MsalAuthPlugin {
+    /// Returns the object of MSAL Authority based on the authority type.
+    /// - Parameter authority: authority URL in string.
+    /// - Returns: `MSALAuthority`.
+    fileprivate func getMsalAuthority(authority: String) throws -> MSALAuthority {
+        switch (MsalAuth.authorityType) {
+            case .b2c:
+            return try MSALB2CAuthority(url: URL(string: authority)!)
+        default:
+            return try MSALAuthority(url: URL(string: authority)!)
+        }
+    }
+    
     /// Returns auth result dictionary. used to set result to Dart.
     /// - Parameter authResult: Auth result.
     /// - Returns: Auth result dictionary.

--- a/lib/src/core/public_client_application.dart
+++ b/lib/src/core/public_client_application.dart
@@ -26,12 +26,18 @@ class PublicClientApplication {
     /// Value is used as an identity provider to pre-fill a user's
     /// email address or username in the login form.
     String? loginHint,
+
+    /// Authority URL to override the default authority.
+    /// Required for "B2C" scenarios where different policies require
+    /// different authorities.
+    String? authority,
   }) async {
     assert(scopes.isNotEmpty, 'Scopes can not be empty');
     final arguments = <String, dynamic>{
       'scopes': scopes,
       'prompt': prompt.name,
       'loginHint': loginHint,
+      'authority': authority,
       'broker': Broker.msAuthenticator.name,
     };
     try {
@@ -56,6 +62,11 @@ class PublicClientApplication {
     /// Account identifier, basically id from account object.
     /// Required for multiple account mode.
     String? identifier,
+
+    /// Optional authority URL to override the cached account's authority.
+    /// Required for B2C scenarios where you want to refresh tokens using
+    /// a different policy than the one used for initial authentication.
+    String? authority,
   }) async {
     assert(scopes.isNotEmpty, 'Scopes can not be empty');
     if (this is MultipleAccountPca) {
@@ -67,6 +78,7 @@ class PublicClientApplication {
     final arguments = <String, dynamic>{
       'scopes': scopes,
       'identifier': identifier,
+      'authority': authority,
     };
     try {
       final result =

--- a/macos/Classes/MsalAuth.swift
+++ b/macos/Classes/MsalAuth.swift
@@ -3,6 +3,7 @@ import MSAL
 /// Singleton class that manages required objects for [MsalAuthPlugin].
 class MsalAuth {
     static var pcaType: PublicClientApplicationType!
+    static var authorityType : AuthorityType!
     static var publicClientApplication: MSALPublicClientApplication!
 }
 
@@ -10,4 +11,10 @@ class MsalAuth {
 enum PublicClientApplicationType {
     case single
     case multiple
+}
+
+/// Authority type.
+enum AuthorityType {
+    case aad
+    case b2c
 }


### PR DESCRIPTION
These changes can be considered as a feature request + also fix the https://github.com/nayanAubie/msal_auth/issues/71

#### The potential reason for #71 could be:
Fetching the authority from a cached account can be risky because the value of authority returned by the cached account is not the same as the policy URL we request during PCA creation. So that can lead to 404 due to the required policy not being found in `acquireTokenSilent`.