### PR TITLE
Refactor MSAL exception handling & handle missing username in AuthenticationResult (Android)

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
@@ -26,6 +26,7 @@ import com.microsoft.identity.client.exception.MsalServiceException
 import com.microsoft.identity.client.exception.MsalUiRequiredException
 import com.microsoft.identity.client.exception.MsalUnsupportedBrokerException
 import com.microsoft.identity.client.exception.MsalUserCancelException
+import com.microsoft.identity.common.java.util.SchemaUtil
 import io.flutter.plugin.common.MethodChannel
 
 /**
@@ -130,7 +131,10 @@ class MsalAuth(internal val context: Context) {
     private fun getCurrentAccountMap(account: IAccount): Map<String, Any?> {
         return mutableMapOf<String, Any?>().apply {
             put("id", account.id)
-            put("username", account.username)
+            put(
+                "username",
+                if (account.username == SchemaUtil.MISSING_FROM_THE_TOKEN_RESPONSE) null else account.username
+            )
             put("name", account.claims?.get("name"))
         }
     }

--- a/example/assets/msal_config.json
+++ b/example/assets/msal_config.json
@@ -1,5 +1,5 @@
 {
-  "authorities" : [
+  "authorities": [
     {
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.com/common",
@@ -28,7 +28,7 @@
       "browser_signature_hashes": [
         "7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg=="
       ],
-      "browser_use_customTab" : true,
+      "browser_use_customTab": true,
       "browser_version_lower_bound": "45"
     },
     {
@@ -36,21 +36,21 @@
       "browser_signature_hashes": [
         "7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
     {
       "browser_package_name": "org.mozilla.firefox",
       "browser_signature_hashes": [
         "2gCe6pR_AO_Q2Vu8Iep-4AsiKNnUHQxu0FaDHO_qa178GByKybdT_BuE8_dYk99G5Uvx_gdONXAOO2EaXidpVQ=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
     {
       "browser_package_name": "org.mozilla.firefox",
       "browser_signature_hashes": [
         "2gCe6pR_AO_Q2Vu8Iep-4AsiKNnUHQxu0FaDHO_qa178GByKybdT_BuE8_dYk99G5Uvx_gdONXAOO2EaXidpVQ=="
       ],
-      "browser_use_customTab" : true,
+      "browser_use_customTab": true,
       "browser_version_lower_bound": "57"
     },
     {
@@ -58,7 +58,7 @@
       "browser_signature_hashes": [
         "ABi2fbt8vkzj7SJ8aD5jc4xJFTDFntdkMrYXL3itsvqY1QIw-dZozdop5rgKNxjbrQAd5nntAGpgh9w84O1Xgg=="
       ],
-      "browser_use_customTab" : true,
+      "browser_use_customTab": true,
       "browser_version_lower_bound": "4.0"
     },
     {
@@ -66,76 +66,70 @@
       "browser_signature_hashes": [
         "ABi2fbt8vkzj7SJ8aD5jc4xJFTDFntdkMrYXL3itsvqY1QIw-dZozdop5rgKNxjbrQAd5nntAGpgh9w84O1Xgg=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
     {
       "browser_package_name": "com.cloudmosa.puffinFree",
       "browser_signature_hashes": [
         "1WqG8SoK2WvE4NTYgr2550TRhjhxT-7DWxu6C_o6GrOLK6xzG67Hq7GCGDjkAFRCOChlo2XUUglLRAYu3Mn8Ag=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
     {
       "browser_package_name": "com.duckduckgo.mobile.android",
       "browser_signature_hashes": [
         "S5Av4cfEycCvIvKPpKGjyCuAE5gZ8y60-knFfGkAEIZWPr9lU5kA7iOAlSZxaJei08s0ruDvuEzFYlmH-jAi4Q=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
     {
       "browser_package_name": "com.explore.web.browser",
       "browser_signature_hashes": [
         "BzDzBVSAwah8f_A0MYJCPOkt0eb7WcIEw6Udn7VLcizjoU3wxAzVisCm6bW7uTs4WpMfBEJYf0nDgzTYvYHCag=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "com.ksmobile.cb",
       "browser_signature_hashes": [
         "lFDYx1Rwc7_XUn4KlfQk2klXLufRyuGHLa3a7rNjqQMkMaxZueQfxukVTvA7yKKp3Md3XUeeDSWGIZcRy7nouw=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "com.microsoft.emmx",
       "browser_signature_hashes": [
         "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "com.opera.browser",
       "browser_signature_hashes": [
         "FIJ3IIeqB7V0qHpRNEpYNkhEGA_eJaf7ntca-Oa_6Feev3UkgnpguTNV31JdAmpEFPGNPo0RHqdlU0k-3jWJWw=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "com.opera.mini.native",
       "browser_signature_hashes": [
         "TOTyHs086iGIEdxrX_24aAewTZxV7Wbi6niS2ZrpPhLkjuZPAh1c3NQ_U4Lx1KdgyhQE4BiS36MIfP6LbmmUYQ=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "mobi.mgeek.TunnyBrowser",
       "browser_signature_hashes": [
         "RMVoXuK1sfJZuGZ8onG1yhMc-sKiAV2NiB_GZfdNlN8XJ78XEE2wPM6LnQiyltF25GkHiPN2iKQiGwaO2bkyyQ=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     },
-
     {
       "browser_package_name": "org.mozilla.focus",
       "browser_signature_hashes": [
         "L72dT-stFqomSY7sYySrgBJ3VYKbipMZapmUXfTZNqOzN_dekT5wdBACJkpz0C6P0yx5EmZ5IciI93Q0hq0oYA=="
       ],
-      "browser_use_customTab" : false
+      "browser_use_customTab": false
     }
   ]
 }

--- a/lib/src/models/exception/msal_argument_exception.dart
+++ b/lib/src/models/exception/msal_argument_exception.dart
@@ -6,24 +6,21 @@ part of 'msal_exception.dart';
 ///
 /// Only occurs in Android platform.
 class MsalArgumentException extends MsalException {
-  /// Detailed error code.
-  final String errorCode;
-
   /// Argument name that has thrown this exception.
   final String argumentName;
 
   /// Operation name provided by SDK.
-  final String operationName;
+  final String? operationName;
 
   const MsalArgumentException({
-    required this.errorCode,
     required this.argumentName,
     required this.operationName,
     required super.message,
+    required super.correlationId,
   });
 
   @override
   String toString() {
-    return 'MsalArgumentException { errorCode: $errorCode, argumentName: $argumentName, operationName: $operationName }';
+    return 'MsalArgumentException { argumentName: $argumentName, operationName: $operationName, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_client_exception.dart
+++ b/lib/src/models/exception/msal_client_exception.dart
@@ -49,10 +49,14 @@ class MsalClientException extends MsalException {
   /// Detailed error code.
   final String errorCode;
 
-  const MsalClientException({required this.errorCode, required super.message});
+  const MsalClientException({
+    required this.errorCode,
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalClientException { errorCode: $errorCode, message: $message }';
+    return 'MsalClientException { errorCode: $errorCode, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_declined_scope_exception.dart
+++ b/lib/src/models/exception/msal_declined_scope_exception.dart
@@ -22,10 +22,11 @@ class MsalDeclinedScopeException extends MsalException {
     required this.grantedScopes,
     required this.declinedScopes,
     required super.message,
+    required super.correlationId,
   });
 
   @override
   String toString() {
-    return 'MsalDeclinedScopeException { grantedScopes: $grantedScopes, declinedScopes: $declinedScopes, message: $message }';
+    return 'MsalDeclinedScopeException { grantedScopes: $grantedScopes, declinedScopes: $declinedScopes, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_exception.dart
+++ b/lib/src/models/exception/msal_exception.dart
@@ -18,10 +18,13 @@ class MsalException implements Exception {
   /// Error message returned by MSAL SDK.
   final String message;
 
-  const MsalException({required this.message});
+  /// Represents UUID used for the request.
+  final String? correlationId;
+
+  const MsalException({required this.message, this.correlationId});
 
   @override
   String toString() {
-    return 'MsalException { message: $message }';
+    return 'MsalException { message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_insufficient_device_strength_exception.dart
+++ b/lib/src/models/exception/msal_insufficient_device_strength_exception.dart
@@ -5,12 +5,15 @@ part of 'msal_exception.dart';
 ///
 /// Workplacejoin migrate device registration is required to proceed.
 ///
-/// Only occurs in iOS platform.
+/// Only occurs in iOS/MacOS platform.
 class MsalInsufficientDeviceStrengthException extends MsalException {
-  const MsalInsufficientDeviceStrengthException({required super.message});
+  const MsalInsufficientDeviceStrengthException({
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalInsufficientDeviceStrengthException { message: $message }';
+    return 'MsalInsufficientDeviceStrengthException { message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_internal_exception.dart
+++ b/lib/src/models/exception/msal_internal_exception.dart
@@ -5,20 +5,22 @@ part of 'msal_exception.dart';
 /// More detailed information about the specific error can be found in
 /// "MSALInternalError" enum.
 ///
-/// Visit this link to check the detailed error by searching your [errorCode].
-/// https://github.com/AzureAD/microsoft-authentication-library-for-objc/blob/dev/MSAL/src/public/MSALError.h
-///
-/// Only occurs in iOS platform.
+/// Only occurs in iOS/MacOS platform.
 class MsalInternalException extends MsalException {
-  final String errorCode;
+  /// Internal error code.
+  ///
+  /// Visit this link to check the detailed error by searching your [errorCode].
+  /// https://github.com/AzureAD/microsoft-authentication-library-for-objc/blob/dev/MSAL/src/public/MSALError.h
+  final int errorCode;
 
   const MsalInternalException({
     required this.errorCode,
     required super.message,
+    required super.correlationId,
   });
 
   @override
   String toString() {
-    return 'MsalInternalException { errorCode: $errorCode, message: $message }';
+    return 'MsalInternalException { errorCode: $errorCode, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_protection_policy_required_exception.dart
+++ b/lib/src/models/exception/msal_protection_policy_required_exception.dart
@@ -6,10 +6,29 @@ part of 'msal_exception.dart';
 /// Handling of this error is optional (handle it only if you are going to
 /// access resources protected by an Intune Conditional Access policy).
 class MsalProtectionPolicyRequiredException extends MsalException {
-  const MsalProtectionPolicyRequiredException({required super.message});
+  /// Account Upn of the user. only present in Android.
+  final String? accountUpn;
+
+  /// Account OID of the user. only present in Android.
+  final String? accountUserId;
+
+  /// Account Tenant id. only present in Android.
+  final String? tenantId;
+
+  /// Authority Url. only present in Android.
+  final String? authorityUrl;
+
+  const MsalProtectionPolicyRequiredException({
+    required this.accountUpn,
+    required this.accountUserId,
+    required this.tenantId,
+    required this.authorityUrl,
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalProtectionPolicyRequiredException { message: $message }';
+    return 'MsalProtectionPolicyRequiredException { accountUpn: $accountUpn, accountUserId: $accountUserId, tenantId: $tenantId, authorityUrl: $authorityUrl, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_server_exception.dart
+++ b/lib/src/models/exception/msal_server_exception.dart
@@ -6,12 +6,15 @@ part of 'msal_exception.dart';
 /// such as a transient failure, misconfiguration, or other
 /// backend-related problems.
 ///
-/// Only occurs in iOS platform.
+/// Only occurs in iOS/MacOS platform.
 class MsalServerException extends MsalException {
-  const MsalServerException({required super.message});
+  const MsalServerException({
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalServerException { message: $message }';
+    return 'MsalServerException { message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_service_exception.dart
+++ b/lib/src/models/exception/msal_service_exception.dart
@@ -33,16 +33,19 @@ class MsalServiceException extends MsalException {
   final String errorCode;
 
   /// The http status code for the request sent to the service.
+  /// When "java.net.SocketTimeoutException" is thrown, no status code
+  /// will be caught. Will use "0" instead.
   final int httpStatusCode;
 
   const MsalServiceException({
     required this.errorCode,
     required this.httpStatusCode,
     required super.message,
+    required super.correlationId,
   });
 
   @override
   String toString() {
-    return 'MsalServiceException { errorCode: $errorCode, httpStatusCode: $httpStatusCode, message: $message }';
+    return 'MsalServiceException { errorCode: $errorCode, httpStatusCode: $httpStatusCode, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_ui_required_exception.dart
+++ b/lib/src/models/exception/msal_ui_required_exception.dart
@@ -11,10 +11,25 @@ part of 'msal_exception.dart';
 ///
 /// Developer should handle this and generally call the "acquireToken()" method.
 class MsalUiRequiredException extends MsalException {
-  const MsalUiRequiredException({required super.message});
+  /// Only present in Android platform.
+  final String? oauthSubErrorCode;
+
+  /// Only present in iOS/MacOS platform.
+  final String? oauthError;
+
+  /// Only present in iOS/MacOS platform.
+  final String? oauthErrorDescription;
+
+  const MsalUiRequiredException({
+    required this.oauthSubErrorCode,
+    required this.oauthError,
+    required this.oauthErrorDescription,
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalUiRequiredException { message: $message }';
+    return 'MsalUiRequiredException { oauthSubErrorCode: $oauthSubErrorCode, oauthError: $oauthError, oauthErrorDescription: $oauthErrorDescription, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_unsupported_broker_exception.dart
+++ b/lib/src/models/exception/msal_unsupported_broker_exception.dart
@@ -5,10 +5,17 @@ part of 'msal_exception.dart';
 ///
 /// Only occurs in Android platform.
 class MsalUnsupportedBrokerException extends MsalException {
-  const MsalUnsupportedBrokerException({required super.message});
+  /// Android package name of the active broker.
+  final String activeBrokerPackageName;
+
+  const MsalUnsupportedBrokerException({
+    required this.activeBrokerPackageName,
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalUnsupportedBrokerException { message: $message }';
+    return 'MsalUnsupportedBrokerException { activeBrokerPackageName: $activeBrokerPackageName, message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_user_cancel_exception.dart
+++ b/lib/src/models/exception/msal_user_cancel_exception.dart
@@ -2,10 +2,13 @@ part of 'msal_exception.dart';
 
 /// MSAL internal exception for user cancelling the flow.
 class MsalUserCancelException extends MsalException {
-  const MsalUserCancelException({required super.message});
+  const MsalUserCancelException({
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalUserCancelException { message: $message }';
+    return 'MsalUserCancelException { message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/models/exception/msal_workplace_join_required_exception.dart
+++ b/lib/src/models/exception/msal_workplace_join_required_exception.dart
@@ -2,12 +2,15 @@ part of 'msal_exception.dart';
 
 /// Workplace join is required to proceed. Handling of this error is optional.
 ///
-/// Only occurs in iOS platform.
+/// Only occurs in iOS/MacOS platform.
 class MsalWorkplaceJoinRequiredException extends MsalException {
-  const MsalWorkplaceJoinRequiredException({required super.message});
+  const MsalWorkplaceJoinRequiredException({
+    required super.message,
+    required super.correlationId,
+  });
 
   @override
   String toString() {
-    return 'MsalWorkplaceJoinRequiredException { message: $message }';
+    return 'MsalWorkplaceJoinRequiredException { message: $message, correlationId: $correlationId }';
   }
 }

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -5,54 +5,72 @@ import '../models/models.dart';
 extension PlatformExceptionUtils on PlatformException {
   /// Converts the [PlatformException] to [MsalException]
   MsalException convertToMsalException() {
-    switch (code) {
-      case 'USER_CANCEL':
-        return MsalUserCancelException(message: message!);
-      case 'DECLINED_SCOPE':
-        final map = details.cast<String, dynamic>();
-        return MsalDeclinedScopeException(
+    final message = this.message ?? '';
+    final map = details.cast<String, dynamic>();
+    final correlationId = map['correlationId'] as String?;
+
+    return switch (code) {
+      'USER_CANCEL' =>
+        MsalUserCancelException(message: message, correlationId: correlationId),
+      'DECLINED_SCOPE' => MsalDeclinedScopeException(
           grantedScopes: map['grantedScopes'].cast<String>(),
           declinedScopes: map['declinedScopes'].cast<String>(),
-          message: message!,
-        );
-      case 'PROTECTION_POLICY_REQUIRED':
-        return MsalProtectionPolicyRequiredException(message: message!);
-      case 'UI_REQUIRED':
-        return MsalUiRequiredException(message: message!);
-      case 'INVALID_ARGUMENT':
-        final map = details.cast<String, dynamic>();
-        return MsalArgumentException(
-          errorCode: map['errorCode'],
+          message: message,
+          correlationId: correlationId,
+        ),
+      'PROTECTION_POLICY_REQUIRED' => MsalProtectionPolicyRequiredException(
+          accountUpn: map['accountUpn'],
+          accountUserId: map['accountUserId'],
+          tenantId: map['tenantId'],
+          authorityUrl: map['authorityUrl'],
+          message: message,
+          correlationId: correlationId,
+        ),
+      'UI_REQUIRED' => MsalUiRequiredException(
+          oauthSubErrorCode: map['oauthSubErrorCode'],
+          oauthError: map['oauthError'],
+          oauthErrorDescription: map['oauthErrorDescription'],
+          message: message,
+          correlationId: correlationId,
+        ),
+      'INVALID_ARGUMENT' => MsalArgumentException(
           argumentName: map['argumentName'],
           operationName: map['operationName'],
-          message: message!,
-        );
-      case 'CLIENT_ERROR':
-        return MsalClientException(
-          errorCode: details,
-          message: message!,
-        );
-      case 'SERVICE_ERROR':
-        final map = details.cast<String, dynamic>();
-        return MsalServiceException(
+          message: message,
+          correlationId: correlationId,
+        ),
+      'CLIENT_ERROR' => MsalClientException(
+          errorCode: map['errorCode'],
+          message: message,
+          correlationId: correlationId,
+        ),
+      'SERVICE_ERROR' => MsalServiceException(
           errorCode: map['errorCode'],
           httpStatusCode: map['httpStatusCode'],
-          message: message!,
-        );
-      case 'UNSUPPORTED_BROKER':
-        return MsalUnsupportedBrokerException(message: message!);
-      case 'INTERNAL_ERROR':
-        return MsalInternalException(
-          message: message!,
-          errorCode: details.toString(),
-        );
-      case 'WORKPLACE_JOIN_REQUIRED':
-        return MsalWorkplaceJoinRequiredException(message: message!);
-      case 'SERVER_ERROR':
-        return MsalServerException(message: message!);
-      case 'INSUFFICIENT_DEVICE_STRENGTH':
-        return MsalInsufficientDeviceStrengthException(message: message!);
-    }
-    return MsalException(message: message ?? '');
+          message: message,
+          correlationId: correlationId,
+        ),
+      'UNSUPPORTED_BROKER' => MsalUnsupportedBrokerException(
+          activeBrokerPackageName: map['activeBrokerPackageName'],
+          message: message,
+          correlationId: correlationId,
+        ),
+      'INTERNAL_ERROR' => MsalInternalException(
+          message: message,
+          correlationId: correlationId,
+          errorCode: map['internalErrorCode'],
+        ),
+      'WORKPLACE_JOIN_REQUIRED' => MsalWorkplaceJoinRequiredException(
+          message: message,
+          correlationId: correlationId,
+        ),
+      'SERVER_ERROR' =>
+        MsalServerException(message: message, correlationId: correlationId),
+      'INSUFFICIENT_DEVICE_STRENGTH' => MsalInsufficientDeviceStrengthException(
+          message: message,
+          correlationId: correlationId,
+        ),
+      _ => MsalException(message: message, correlationId: correlationId),
+    };
   }
 }

--- a/macos/Classes/MsalAuthPlugin.swift
+++ b/macos/Classes/MsalAuthPlugin.swift
@@ -509,47 +509,49 @@ extension MsalAuthPlugin {
     fileprivate func setMsalError(
         error: NSError, result: @escaping FlutterResult
     ) {
-        var code: String!
-        var errorDetails: Any? = nil
+        var flutterErrorCode: String!
+        var errorMessage: Any?
+        var errorDetails = [String: Any]()
 
         if error.domain == MSALErrorDomain,
             let errorCode = MSALError(rawValue: error.code)
         {
+            errorMessage = error.userInfo[MSALErrorDescriptionKey]
+            errorDetails["correlationId"] = error.userInfo[MSALCorrelationIDKey]
+            
             switch errorCode {
             case .userCanceled:
-                code = "USER_CANCEL"
+                flutterErrorCode = "USER_CANCEL"
             case .serverDeclinedScopes:
-                code = "DECLINED_SCOPE"
-                var details = [String: Any]()
-                details["grantedScopes"] = error.userInfo[MSALGrantedScopesKey]
-                details["declinedScopes"] =
-                    error.userInfo[MSALDeclinedScopesKey]
-                errorDetails = details
+                flutterErrorCode = "DECLINED_SCOPE"
+                errorDetails["grantedScopes"] = error.userInfo[MSALGrantedScopesKey]
+                errorDetails["declinedScopes"] = error.userInfo[MSALDeclinedScopesKey]
             case .serverProtectionPoliciesRequired:
-                code = "PROTECTION_POLICY_REQUIRED"
+                flutterErrorCode = "PROTECTION_POLICY_REQUIRED"
             case .interactionRequired:
-                code = "UI_REQUIRED"
+                flutterErrorCode = "UI_REQUIRED"
+                errorDetails["oauthError"] = error.userInfo[MSALOAuthErrorKey]
+                errorDetails["oauthErrorDescription"] = error.userInfo[MSALOAuthSubErrorDescriptionKey]
             case .internal:
-                code = "INTERNAL_ERROR"
-                errorDetails = error.userInfo[MSALInternalErrorCodeKey]
+                flutterErrorCode = "INTERNAL_ERROR"
+                errorDetails["internalErrorCode"] = error.userInfo[MSALInternalErrorCodeKey]
             case .workplaceJoinRequired:
-                code = "WORKPLACE_JOIN_REQUIRED"
+                flutterErrorCode = "WORKPLACE_JOIN_REQUIRED"
             case .serverError:
-                code = "SERVER_ERROR"
+                flutterErrorCode = "SERVER_ERROR"
             case .insufficientDeviceStrength:
-                code = "INSUFFICIENT_DEVICE_STRENGTH"
+                flutterErrorCode = "INSUFFICIENT_DEVICE_STRENGTH"
             @unknown default:
-                code = "INTERNAL_ERROR"
-                errorDetails = "unknown"
+                break
             }
         } else {
-            code = "INTERNAL_ERROR"
-            errorDetails = error.domain
+            flutterErrorCode = error.domain
+            errorMessage = error.localizedDescription
         }
 
         result(
             FlutterError(
-                code: code, message: error.localizedDescription,
+                code: flutterErrorCode, message: errorMessage as? String,
                 details: errorDetails))
     }
 }


### PR DESCRIPTION
### MSAL exception handling

- Used `MSALErrorDescriptionKey` from the `userInfo` map to get the proper exception message in iOS/MacOS
- Added parameters in the relevant **MSAL exception classes** (based on what particular platform returns)
- Added `correlationId` param in `MsalException` class

### AuthenticationResult changes

- In Android, in some cases (mostly observed in `B2C`), the `username` in `authenticationResult.account` returns the value `Missing from token response` in Android. Fixed using turnory in the Kotlin class. Though the same applies to `authority` sometimes, but that's okay. 