### PR TITLE
Add MsalNoCurrentAccountException to handle absence of signed-in account

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
@@ -169,7 +169,7 @@ class MsalAuth(internal val context: Context) {
      */
     internal fun currentAccountCallback(result: MethodChannel.Result): CurrentAccountCallback {
         // MSAL may invoke multiple callbacks (`onAccountLoaded` and `onAccountChanged`) when logged-in user clears
-        // the app storage and trys to call `getCurrentAccount` method directly after opening the app. #issue/116
+        // the app storage and try to call `getCurrentAccount` method directly after opening the app. #issue/116
         var replied = false
 
         return object : CurrentAccountCallback {
@@ -268,11 +268,11 @@ class MsalAuth(internal val context: Context) {
      * Sets no current account exception.
      */
     internal fun setNoCurrentAccountException(result: MethodChannel.Result) {
-        setMsalException(
-            MsalClientException(
-                MsalClientException.NO_CURRENT_ACCOUNT,
-                MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE
-            ), result
+        // Send the exception "NO_CURRENT_ACCOUNT" directly to Flutter
+        result.error(
+            MsalClientException.NO_CURRENT_ACCOUNT.uppercase(),
+            MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE,
+            null
         )
     }
 

--- a/lib/src/models/exception/msal_exception.dart
+++ b/lib/src/models/exception/msal_exception.dart
@@ -3,6 +3,7 @@ part 'msal_client_exception.dart';
 part 'msal_declined_scope_exception.dart';
 part 'msal_insufficient_device_strength_exception.dart';
 part 'msal_internal_exception.dart';
+part 'msal_no_current_account_exception.dart';
 part 'msal_pca_init_exception.dart';
 part 'msal_protection_policy_required_exception.dart';
 part 'msal_server_exception.dart';

--- a/lib/src/models/exception/msal_no_current_account_exception.dart
+++ b/lib/src/models/exception/msal_no_current_account_exception.dart
@@ -1,0 +1,14 @@
+part of 'msal_exception.dart';
+
+/// Customized exception created in Dart to handle the case of no signed in
+/// account as native SDK does not throw any dedicated exception.
+class MsalNoCurrentAccountException extends MsalException {
+  const MsalNoCurrentAccountException({
+    required super.message,
+  });
+
+  @override
+  String toString() {
+    return 'MsalNoCurrentAccountException { message: $message, correlationId: $correlationId }';
+  }
+}

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -71,6 +71,7 @@ extension PlatformExceptionUtils on PlatformException {
           message: message,
           correlationId: correlationId,
         ),
+      'NO_CURRENT_ACCOUNT' => MsalNoCurrentAccountException(message: message),
       _ => MsalException(message: message, correlationId: correlationId),
     };
   }


### PR DESCRIPTION
## Fix

- Android was sending `MsalClientException` manually with the Flutter error code `CLIENT_ERROR` and so it was treated as a client exception on the Dart side, but iOS was sending `NO_CURRENT_ACCOUNT` error code directly via `FlutterError`, but that was not mapped into a dedicated exception on the Dart side.
- So this PR introduces `MsalNoCurrentAccountException` on Dart and triggered via `NO_CURRENT_ACCOUNT` error code sent via native.